### PR TITLE
parser: enable custom error handling

### DIFF
--- a/parser/gen/golang/errors.go
+++ b/parser/gen/golang/errors.go
@@ -50,6 +50,7 @@ type Error struct {
 	ErrorToken     *token.Token
 	ErrorSymbols   []ErrorSymbol
 	ExpectedTokens []string
+	StackTop       int
 }
 
 func (E *Error) String() string {
@@ -69,6 +70,20 @@ func (E *Error) String() string {
 	fmt.Fprintf(w, "ErrorSymbol:\n")
 	for _, sym := range E.ErrorSymbols {
 		fmt.Fprintf(w, "%v\n", sym)
+	}
+	return w.String()
+}
+
+func (e *Error) Error() string {
+	w := new(bytes.Buffer)
+	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
+	if e.Err != nil {
+		w.WriteString(e.Err.Error())
+	} else {
+		w.WriteString(", expected one of: ")
+		for _, expected := range e.ExpectedTokens {
+			fmt.Fprintf(w, "%s ", expected)
+		}
 	}
 	return w.String()
 }


### PR DESCRIPTION
While implementing a simple compiler for a subset of C, we wanted to add user-friendly error messages, and therefore started looking for ways of integrating them into the Gocc generated parser.

As Gocc has support for `error` production rules, this was the obvious mechanism to hook into. However, the errors reported were verbose and while helpful to a compiler developer, they were not user-friendly for end-users of the compiler.

To mitigate this issue, we implemented a way of creating custom error messages, using the builtin `error` interface of Go, to keep the current error messages as is, while enabling extensions (through type assertions).

An example using the updated code is provided below, using [uparse](https://github.com/mewmew/uc/blob/db976f881abc76f9806d71fca1eb3b2083627c12/cmd/uparse/uparse.go) to parse the incorrect input file [testdata/incorrect/parser/pe01.c ](https://github.com/mewmew/uc/blob/db976f881abc76f9806d71fca1eb3b2083627c12/testdata/incorrect/parser/pe01.c).

### Before

* uparse from commit [5f744176565bb4a797828b4ce981fbd16903af40](https://github.com/mewmew/uc/tree/5f744176565bb4a797828b4ce981fbd16903af40)

```
u@x1 ~/D/g/s/g/m/uc> uparse testdata/incorrect/parser/pe01.c 
Parsing "testdata/incorrect/parser/pe01.c"
2016/04/13 00:38:44 main.parseFile (uparse.go:85): error: Error in S157: )(6,)), Pos(offset=102, line=0, column=0)102: expected ["ident" "(" "int_lit" "-" "!"], got ")"
```

### After

* uparse from commit mewmew/uc@db976f881abc76f9806d71fca1eb3b2083627c12

```
u@x1 ~/D/g/s/g/m/uc> uparse testdata/incorrect/parser/pe01.c 
Parsing "testdata/incorrect/parser/pe01.c"
2016/04/13 00:39:37 main.parseFile (uparse.go:88): error: 102: expected ["ident" "(" "int_lit" "-" "!"], got ")"
```
