### PR TITLE
Fix line and column fields in tokens.

### DIFF
--- a/lexer/gen/golang/lexer.go
+++ b/lexer/gen/golang/lexer.go
@@ -120,7 +120,7 @@ func (this *Lexer) Scan() (tok *token.Token) {
 		tok.Pos.Offset, tok.Pos.Line, tok.Pos.Column = this.pos, this.line, this.column
 		return
 	}
-	start, end := this.pos, 0
+	start, startLine, startColumn, end := this.pos, this.line, this.column, 0
 	tok.Type = token.INVALID
 	state, rune1, size := 0, rune(-1), 0
 	for state != -1 {
@@ -201,7 +201,7 @@ func (this *Lexer) Scan() (tok *token.Token) {
 				end = this.pos
 			case ActTab[state].Ignore != "":
 				// fmt.Printf("\t Ignore(%s)\n", string(act))
-				start = this.pos
+				start, startLine, startColumn = this.pos, this.line, this.column
 				state = 0
 				if start >= len(this.src) {
 					tok.Type = token.EOF
@@ -220,9 +220,14 @@ func (this *Lexer) Scan() (tok *token.Token) {
 	} else {
 		tok.Lit = []byte{}
 	}
-	tok.Pos.Offset = start
-	tok.Pos.Column = this.column
-	tok.Pos.Line = this.line
+	tok.Pos.Offset, tok.Pos.Line ,tok.Pos.Column = start, startLine, startColumn
+
+	{{if .Debug}}
+	fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
+	{{else}}
+	// fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
+	{{end}}
+
 	return
 }
 

--- a/lexer/gen/golang/lexer.go
+++ b/lexer/gen/golang/lexer.go
@@ -135,17 +135,6 @@ func (this *Lexer) Scan() (tok *token.Token) {
 			rune1, size = utf8.DecodeRune(this.src[this.pos:])
 			this.pos += size
 		}
-		switch rune1 {
-		case '\n':
-			this.line++
-			this.column = 1
-		case '\r':
-			this.column = 1
-		case '\t':
-			this.column += 4
-		default:
-			this.column++
-		}
 
 	{{if .Debug}}
 		// Production start
@@ -192,6 +181,19 @@ func (this *Lexer) Scan() (tok *token.Token) {
 	{{end}}
 
 		if state != -1 {
+
+			switch rune1 {
+			case '\n':
+				this.line++
+				this.column = 1
+			case '\r':
+				this.column = 1
+			case '\t':
+				this.column += 4
+			default:
+				this.column++
+			}
+
 			switch {
 			case ActTab[state].Accept != -1:
 				tok.Type = ActTab[state].Accept

--- a/lexer/gen/golang/lexer.go
+++ b/lexer/gen/golang/lexer.go
@@ -81,7 +81,6 @@ const(
 	NoState = -1
 	NumStates = {{.NumStates}}
 	NumSymbols = {{.NumSymbols}}
-	DEFAULT_TABSIZE = 4
 )
 
 type Lexer struct {
@@ -89,20 +88,14 @@ type Lexer struct {
 	pos             int
 	line            int
 	column          int
-	tabsize			int
 }
 
 func NewLexer(src []byte) *Lexer {
-	return NewLexerTabSize(src, DEFAULT_TABSIZE)
-}
-
-func NewLexerTabSize(src []byte, tabsize int) *Lexer {
 	lexer := &Lexer{
-		src:     src,
-		pos:     0,
-		line:    1,
-		column:  1,
-		tabsize: tabsize,
+		src:    src,
+		pos:    0,
+		line:   1,
+		column: 1,
 	}
 	return lexer
 }
@@ -113,29 +106,6 @@ func NewLexerFile(fpath string) (*Lexer, error) {
 		return nil, err
 	}
 	return NewLexer(src), nil
-}
-
-/*
-Return (line, column) of offset in this.src given this.tabsize.
-line and column have range 1..n
-*/
-func (this *Lexer) GetPosition(offset int) (line, column int) {
-	line, column = 1, 1
-	for o := 0; o < offset && o < len(this.src); {
-		rune1, size := utf8.DecodeRune(this.src[o:])
-		o += size
-		switch rune1 {
-		case '\n':
-			line++
-			column = 1
-		case '\t':
-			column += this.tabsize
-		default:
-			column++
-		}
-
-	}
-	return
 }
 
 func (this *Lexer) Scan() (tok *token.Token) {

--- a/parser/gen/golang/parser.go
+++ b/parser/gen/golang/parser.go
@@ -147,7 +147,6 @@ type Parser struct {
 
 type Scanner interface {
 	Scan() (tok *token.Token)
-	GetPosition(int) (int, int)
 }
 
 func NewParser() *Parser {
@@ -168,9 +167,6 @@ func (P *Parser) Error(err error, scanner Scanner) (recovered bool, errorAttrib 
 		ErrorSymbols:   P.popNonRecoveryStates(),
 		ExpectedTokens: make([]string, 0, 8),
 	}
-	errorAttrib.ErrorToken.Pos.Line, errorAttrib.ErrorToken.Pos.Column =
-		scanner.GetPosition(errorAttrib.ErrorToken.Pos.Offset)
-		
 	for t, action := range actionTab[P.stack.top()].actions {
 		if action != nil {
 			errorAttrib.ExpectedTokens = append(errorAttrib.ExpectedTokens, token.TokMap.Id(token.Type(t)))

--- a/parser/gen/golang/parser.go
+++ b/parser/gen/golang/parser.go
@@ -219,14 +219,12 @@ func (P *Parser) firstRecoveryState() (recoveryState int, canRecover bool) {
 	return
 }
 
-func (P *Parser) newError(err error, scanner Scanner) error {
+func (P *Parser) newError(err error) error {
 	e := &parseError.Error{
 		Err:        err,
 		StackTop:   P.stack.top(),
 		ErrorToken: P.nextToken,
 	}
-	e.ErrorToken.Pos.Line, e.ErrorToken.Pos.Column =
-		scanner.GetPosition(e.ErrorToken.Pos.Offset)
 	actRow := actionTab[P.stack.top()]
 	for i, t := range actRow.actions {
 		if t != nil {
@@ -244,7 +242,7 @@ func (this *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 		if action == nil {
 			if recovered, errAttrib := this.Error(nil, scanner); !recovered {
 				this.nextToken = errAttrib.ErrorToken
-				return nil, this.newError(nil, scanner)
+				return nil, this.newError(nil)
 			}
 			if action = actionTab[this.stack.top()].actions[this.nextToken.Type]; action == nil {
 				panic("Error recovery led to invalid action")
@@ -267,7 +265,7 @@ func (this *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 			prod := productionsTable[int(act)]
 			attrib, err := prod.ReduceFunc(this.stack.popN(prod.NumSymbols))
 			if err != nil {
-				return nil, this.newError(err, scanner)
+				return nil, this.newError(err)
 			} else {
 				this.stack.push(gotoTab[this.stack.top()][prod.NTType], attrib)
 			}

--- a/test/t1/t1_test.go
+++ b/test/t1/t1_test.go
@@ -3,6 +3,7 @@ package t1
 import (
 	"testing"
 
+	"github.com/goccmack/gocc/test/t1/errors"
 	"github.com/goccmack/gocc/test/t1/lexer"
 	"github.com/goccmack/gocc/test/t1/parser"
 )
@@ -55,6 +56,21 @@ func Test2(t *testing.T) {
 			if str != "c" {
 				t.Fatal(`str != "c"`)
 			}
+		}
+	}
+}
+
+func Test3(t *testing.T) {
+	toks := lexer.NewLexer([]byte(`c b`))
+	_, err := parser.NewParser().Parse(toks)
+	if err == nil {
+		t.Fatal("No error for erronous input.")
+	}
+	if errs, ok := err.(*errors.Error); !ok {
+		t.Fatal("Incompatible error type for erronous input.")
+	} else {
+		if errs.ErrorToken.Column != 3 {
+			t.Fatal("errs.ErrorToken.Column = ", errs.ErrorToken.Column, " != 3")
 		}
 	}
 }


### PR DESCRIPTION
Also adds one test case for column which fails before fix. Reverts old hack with variable tabsize. Can be fixed in separate issue. 

Updates #14.
Replaces #19.