### PR TITLE
internal: Remove commented out debug fmt.Prints.

### DIFF
--- a/example/astx/lexer/lexer.go
+++ b/example/astx/lexer/lexer.go
@@ -3,11 +3,9 @@
 package lexer
 
 import (
-	// "fmt"
 	"io/ioutil"
 	"unicode/utf8"
 
-	// "github.com/goccmack/gocc/example/astx/util"
 	"github.com/goccmack/gocc/example/astx/token"
 )
 
@@ -43,7 +41,6 @@ func NewLexerFile(fpath string) (*Lexer, error) {
 }
 
 func (l *Lexer) Scan() (tok *token.Token) {
-	// fmt.Printf("Lexer.Scan() pos=%d\n", l.pos)
 	tok = new(token.Token)
 	if l.pos >= len(l.src) {
 		tok.Type = token.EOF
@@ -54,33 +51,18 @@ func (l *Lexer) Scan() (tok *token.Token) {
 	tok.Type = token.INVALID
 	state, rune1, size := 0, rune(-1), 0
 	for state != -1 {
-		// fmt.Printf("\tpos=%d, line=%d, col=%d, state=%d\n", l.pos, l.line, l.column, state)
 		if l.pos >= len(l.src) {
 			rune1 = -1
 		} else {
 			rune1, size = utf8.DecodeRune(l.src[l.pos:])
 			l.pos += size
 		}
-		// Production start
-		if rune1 != -1 {
-			state = TransTab[state](rune1)
-		} else {
-			state = -1
-		}
-		// Production end
 
-		// Debug start
-		// nextState := -1
-		// if rune1 != -1 {
-		// 	nextState = TransTab[state](rune1)
-		// }
-		// fmt.Printf("\tS%d, : tok=%s, rune == %s(%x), next state == %d\n", state, token.TokMap.Id(tok.Type), util.RuneToString(rune1), rune1, nextState)
-		// fmt.Printf("\t\tpos=%d, size=%d, start=%d, end=%d\n", l.pos, size, start, end)
-		// if nextState != -1 {
-		// 	fmt.Printf("\t\taction:%s\n", ActTab[nextState].String())
-		// }
-		// state = nextState
-		// Debug end
+		nextState := -1
+		if rune1 != -1 {
+			nextState = TransTab[state](rune1)
+		}
+		state = nextState
 
 		if state != -1 {
 
@@ -99,10 +81,8 @@ func (l *Lexer) Scan() (tok *token.Token) {
 			switch {
 			case ActTab[state].Accept != -1:
 				tok.Type = ActTab[state].Accept
-				// fmt.Printf("\t Accept(%s), %s(%d)\n", string(act), token.TokMap.Id(tok), tok)
 				end = l.pos
 			case ActTab[state].Ignore != "":
-				// fmt.Printf("\t Ignore(%s)\n", string(act))
 				start, startLine, startColumn = l.pos, l.line, l.column
 				state = 0
 				if start >= len(l.src) {
@@ -123,7 +103,6 @@ func (l *Lexer) Scan() (tok *token.Token) {
 		tok.Lit = []byte{}
 	}
 	tok.Pos.Offset, tok.Pos.Line, tok.Pos.Column = start, startLine, startColumn
-	// fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
 
 	return
 }

--- a/example/astx/parser/parser.go
+++ b/example/astx/parser/parser.go
@@ -187,7 +187,6 @@ func (p *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 				panic("Error recovery led to invalid action")
 			}
 		}
-		// fmt.Printf("S%d %s %s\n", p.stack.top(), token.TokMap.TokenString(p.nextToken), action)
 
 		switch act := action.(type) {
 		case accept:

--- a/example/bools/lexer/lexer.go
+++ b/example/bools/lexer/lexer.go
@@ -3,11 +3,9 @@
 package lexer
 
 import (
-	// "fmt"
 	"io/ioutil"
 	"unicode/utf8"
 
-	// "github.com/goccmack/gocc/example/bools/util"
 	"github.com/goccmack/gocc/example/bools/token"
 )
 
@@ -43,7 +41,6 @@ func NewLexerFile(fpath string) (*Lexer, error) {
 }
 
 func (l *Lexer) Scan() (tok *token.Token) {
-	// fmt.Printf("Lexer.Scan() pos=%d\n", l.pos)
 	tok = new(token.Token)
 	if l.pos >= len(l.src) {
 		tok.Type = token.EOF
@@ -54,33 +51,18 @@ func (l *Lexer) Scan() (tok *token.Token) {
 	tok.Type = token.INVALID
 	state, rune1, size := 0, rune(-1), 0
 	for state != -1 {
-		// fmt.Printf("\tpos=%d, line=%d, col=%d, state=%d\n", l.pos, l.line, l.column, state)
 		if l.pos >= len(l.src) {
 			rune1 = -1
 		} else {
 			rune1, size = utf8.DecodeRune(l.src[l.pos:])
 			l.pos += size
 		}
-		// Production start
-		if rune1 != -1 {
-			state = TransTab[state](rune1)
-		} else {
-			state = -1
-		}
-		// Production end
 
-		// Debug start
-		// nextState := -1
-		// if rune1 != -1 {
-		// 	nextState = TransTab[state](rune1)
-		// }
-		// fmt.Printf("\tS%d, : tok=%s, rune == %s(%x), next state == %d\n", state, token.TokMap.Id(tok.Type), util.RuneToString(rune1), rune1, nextState)
-		// fmt.Printf("\t\tpos=%d, size=%d, start=%d, end=%d\n", l.pos, size, start, end)
-		// if nextState != -1 {
-		// 	fmt.Printf("\t\taction:%s\n", ActTab[nextState].String())
-		// }
-		// state = nextState
-		// Debug end
+		nextState := -1
+		if rune1 != -1 {
+			nextState = TransTab[state](rune1)
+		}
+		state = nextState
 
 		if state != -1 {
 
@@ -99,10 +81,8 @@ func (l *Lexer) Scan() (tok *token.Token) {
 			switch {
 			case ActTab[state].Accept != -1:
 				tok.Type = ActTab[state].Accept
-				// fmt.Printf("\t Accept(%s), %s(%d)\n", string(act), token.TokMap.Id(tok), tok)
 				end = l.pos
 			case ActTab[state].Ignore != "":
-				// fmt.Printf("\t Ignore(%s)\n", string(act))
 				start, startLine, startColumn = l.pos, l.line, l.column
 				state = 0
 				if start >= len(l.src) {
@@ -123,7 +103,6 @@ func (l *Lexer) Scan() (tok *token.Token) {
 		tok.Lit = []byte{}
 	}
 	tok.Pos.Offset, tok.Pos.Line, tok.Pos.Column = start, startLine, startColumn
-	// fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
 
 	return
 }

--- a/example/bools/parser/parser.go
+++ b/example/bools/parser/parser.go
@@ -187,7 +187,6 @@ func (p *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 				panic("Error recovery led to invalid action")
 			}
 		}
-		// fmt.Printf("S%d %s %s\n", p.stack.top(), token.TokMap.TokenString(p.nextToken), action)
 
 		switch act := action.(type) {
 		case accept:

--- a/example/calc/lexer/lexer.go
+++ b/example/calc/lexer/lexer.go
@@ -3,11 +3,9 @@
 package lexer
 
 import (
-	// "fmt"
 	"io/ioutil"
 	"unicode/utf8"
 
-	// "github.com/goccmack/gocc/example/calc/util"
 	"github.com/goccmack/gocc/example/calc/token"
 )
 
@@ -43,7 +41,6 @@ func NewLexerFile(fpath string) (*Lexer, error) {
 }
 
 func (l *Lexer) Scan() (tok *token.Token) {
-	// fmt.Printf("Lexer.Scan() pos=%d\n", l.pos)
 	tok = new(token.Token)
 	if l.pos >= len(l.src) {
 		tok.Type = token.EOF
@@ -54,33 +51,18 @@ func (l *Lexer) Scan() (tok *token.Token) {
 	tok.Type = token.INVALID
 	state, rune1, size := 0, rune(-1), 0
 	for state != -1 {
-		// fmt.Printf("\tpos=%d, line=%d, col=%d, state=%d\n", l.pos, l.line, l.column, state)
 		if l.pos >= len(l.src) {
 			rune1 = -1
 		} else {
 			rune1, size = utf8.DecodeRune(l.src[l.pos:])
 			l.pos += size
 		}
-		// Production start
-		if rune1 != -1 {
-			state = TransTab[state](rune1)
-		} else {
-			state = -1
-		}
-		// Production end
 
-		// Debug start
-		// nextState := -1
-		// if rune1 != -1 {
-		// 	nextState = TransTab[state](rune1)
-		// }
-		// fmt.Printf("\tS%d, : tok=%s, rune == %s(%x), next state == %d\n", state, token.TokMap.Id(tok.Type), util.RuneToString(rune1), rune1, nextState)
-		// fmt.Printf("\t\tpos=%d, size=%d, start=%d, end=%d\n", l.pos, size, start, end)
-		// if nextState != -1 {
-		// 	fmt.Printf("\t\taction:%s\n", ActTab[nextState].String())
-		// }
-		// state = nextState
-		// Debug end
+		nextState := -1
+		if rune1 != -1 {
+			nextState = TransTab[state](rune1)
+		}
+		state = nextState
 
 		if state != -1 {
 
@@ -99,10 +81,8 @@ func (l *Lexer) Scan() (tok *token.Token) {
 			switch {
 			case ActTab[state].Accept != -1:
 				tok.Type = ActTab[state].Accept
-				// fmt.Printf("\t Accept(%s), %s(%d)\n", string(act), token.TokMap.Id(tok), tok)
 				end = l.pos
 			case ActTab[state].Ignore != "":
-				// fmt.Printf("\t Ignore(%s)\n", string(act))
 				start, startLine, startColumn = l.pos, l.line, l.column
 				state = 0
 				if start >= len(l.src) {
@@ -123,7 +103,6 @@ func (l *Lexer) Scan() (tok *token.Token) {
 		tok.Lit = []byte{}
 	}
 	tok.Pos.Offset, tok.Pos.Line, tok.Pos.Column = start, startLine, startColumn
-	// fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
 
 	return
 }

--- a/example/calc/parser/parser.go
+++ b/example/calc/parser/parser.go
@@ -187,7 +187,6 @@ func (p *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 				panic("Error recovery led to invalid action")
 			}
 		}
-		// fmt.Printf("S%d %s %s\n", p.stack.top(), token.TokMap.TokenString(p.nextToken), action)
 
 		switch act := action.(type) {
 		case accept:

--- a/example/errorrecovery/lexer/lexer.go
+++ b/example/errorrecovery/lexer/lexer.go
@@ -3,11 +3,9 @@
 package lexer
 
 import (
-	// "fmt"
 	"io/ioutil"
 	"unicode/utf8"
 
-	// "github.com/goccmack/gocc/example/errorrecovery/util"
 	"github.com/goccmack/gocc/example/errorrecovery/token"
 )
 
@@ -43,7 +41,6 @@ func NewLexerFile(fpath string) (*Lexer, error) {
 }
 
 func (l *Lexer) Scan() (tok *token.Token) {
-	// fmt.Printf("Lexer.Scan() pos=%d\n", l.pos)
 	tok = new(token.Token)
 	if l.pos >= len(l.src) {
 		tok.Type = token.EOF
@@ -54,33 +51,18 @@ func (l *Lexer) Scan() (tok *token.Token) {
 	tok.Type = token.INVALID
 	state, rune1, size := 0, rune(-1), 0
 	for state != -1 {
-		// fmt.Printf("\tpos=%d, line=%d, col=%d, state=%d\n", l.pos, l.line, l.column, state)
 		if l.pos >= len(l.src) {
 			rune1 = -1
 		} else {
 			rune1, size = utf8.DecodeRune(l.src[l.pos:])
 			l.pos += size
 		}
-		// Production start
-		if rune1 != -1 {
-			state = TransTab[state](rune1)
-		} else {
-			state = -1
-		}
-		// Production end
 
-		// Debug start
-		// nextState := -1
-		// if rune1 != -1 {
-		// 	nextState = TransTab[state](rune1)
-		// }
-		// fmt.Printf("\tS%d, : tok=%s, rune == %s(%x), next state == %d\n", state, token.TokMap.Id(tok.Type), util.RuneToString(rune1), rune1, nextState)
-		// fmt.Printf("\t\tpos=%d, size=%d, start=%d, end=%d\n", l.pos, size, start, end)
-		// if nextState != -1 {
-		// 	fmt.Printf("\t\taction:%s\n", ActTab[nextState].String())
-		// }
-		// state = nextState
-		// Debug end
+		nextState := -1
+		if rune1 != -1 {
+			nextState = TransTab[state](rune1)
+		}
+		state = nextState
 
 		if state != -1 {
 
@@ -99,10 +81,8 @@ func (l *Lexer) Scan() (tok *token.Token) {
 			switch {
 			case ActTab[state].Accept != -1:
 				tok.Type = ActTab[state].Accept
-				// fmt.Printf("\t Accept(%s), %s(%d)\n", string(act), token.TokMap.Id(tok), tok)
 				end = l.pos
 			case ActTab[state].Ignore != "":
-				// fmt.Printf("\t Ignore(%s)\n", string(act))
 				start, startLine, startColumn = l.pos, l.line, l.column
 				state = 0
 				if start >= len(l.src) {
@@ -123,7 +103,6 @@ func (l *Lexer) Scan() (tok *token.Token) {
 		tok.Lit = []byte{}
 	}
 	tok.Pos.Offset, tok.Pos.Line, tok.Pos.Column = start, startLine, startColumn
-	// fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
 
 	return
 }

--- a/example/errorrecovery/parser/parser.go
+++ b/example/errorrecovery/parser/parser.go
@@ -187,7 +187,6 @@ func (p *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 				panic("Error recovery led to invalid action")
 			}
 		}
-		// fmt.Printf("S%d %s %s\n", p.stack.top(), token.TokMap.TokenString(p.nextToken), action)
 
 		switch act := action.(type) {
 		case accept:

--- a/example/mail/lexer/lexer.go
+++ b/example/mail/lexer/lexer.go
@@ -3,11 +3,9 @@
 package lexer
 
 import (
-	// "fmt"
 	"io/ioutil"
 	"unicode/utf8"
 
-	// "github.com/goccmack/gocc/example/mail/util"
 	"github.com/goccmack/gocc/example/mail/token"
 )
 
@@ -43,7 +41,6 @@ func NewLexerFile(fpath string) (*Lexer, error) {
 }
 
 func (l *Lexer) Scan() (tok *token.Token) {
-	// fmt.Printf("Lexer.Scan() pos=%d\n", l.pos)
 	tok = new(token.Token)
 	if l.pos >= len(l.src) {
 		tok.Type = token.EOF
@@ -54,33 +51,18 @@ func (l *Lexer) Scan() (tok *token.Token) {
 	tok.Type = token.INVALID
 	state, rune1, size := 0, rune(-1), 0
 	for state != -1 {
-		// fmt.Printf("\tpos=%d, line=%d, col=%d, state=%d\n", l.pos, l.line, l.column, state)
 		if l.pos >= len(l.src) {
 			rune1 = -1
 		} else {
 			rune1, size = utf8.DecodeRune(l.src[l.pos:])
 			l.pos += size
 		}
-		// Production start
-		if rune1 != -1 {
-			state = TransTab[state](rune1)
-		} else {
-			state = -1
-		}
-		// Production end
 
-		// Debug start
-		// nextState := -1
-		// if rune1 != -1 {
-		// 	nextState = TransTab[state](rune1)
-		// }
-		// fmt.Printf("\tS%d, : tok=%s, rune == %s(%x), next state == %d\n", state, token.TokMap.Id(tok.Type), util.RuneToString(rune1), rune1, nextState)
-		// fmt.Printf("\t\tpos=%d, size=%d, start=%d, end=%d\n", l.pos, size, start, end)
-		// if nextState != -1 {
-		// 	fmt.Printf("\t\taction:%s\n", ActTab[nextState].String())
-		// }
-		// state = nextState
-		// Debug end
+		nextState := -1
+		if rune1 != -1 {
+			nextState = TransTab[state](rune1)
+		}
+		state = nextState
 
 		if state != -1 {
 
@@ -99,10 +81,8 @@ func (l *Lexer) Scan() (tok *token.Token) {
 			switch {
 			case ActTab[state].Accept != -1:
 				tok.Type = ActTab[state].Accept
-				// fmt.Printf("\t Accept(%s), %s(%d)\n", string(act), token.TokMap.Id(tok), tok)
 				end = l.pos
 			case ActTab[state].Ignore != "":
-				// fmt.Printf("\t Ignore(%s)\n", string(act))
 				start, startLine, startColumn = l.pos, l.line, l.column
 				state = 0
 				if start >= len(l.src) {
@@ -123,7 +103,6 @@ func (l *Lexer) Scan() (tok *token.Token) {
 		tok.Lit = []byte{}
 	}
 	tok.Pos.Offset, tok.Pos.Line, tok.Pos.Column = start, startLine, startColumn
-	// fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
 
 	return
 }

--- a/example/nolexer/parser/parser.go
+++ b/example/nolexer/parser/parser.go
@@ -187,7 +187,6 @@ func (p *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 				panic("Error recovery led to invalid action")
 			}
 		}
-		// fmt.Printf("S%d %s %s\n", p.stack.top(), token.TokMap.TokenString(p.nextToken), action)
 
 		switch act := action.(type) {
 		case accept:

--- a/example/rr/lexer/lexer.go
+++ b/example/rr/lexer/lexer.go
@@ -3,11 +3,9 @@
 package lexer
 
 import (
-	// "fmt"
 	"io/ioutil"
 	"unicode/utf8"
 
-	// "github.com/goccmack/gocc/example/rr/util"
 	"github.com/goccmack/gocc/example/rr/token"
 )
 
@@ -43,7 +41,6 @@ func NewLexerFile(fpath string) (*Lexer, error) {
 }
 
 func (l *Lexer) Scan() (tok *token.Token) {
-	// fmt.Printf("Lexer.Scan() pos=%d\n", l.pos)
 	tok = new(token.Token)
 	if l.pos >= len(l.src) {
 		tok.Type = token.EOF
@@ -54,33 +51,18 @@ func (l *Lexer) Scan() (tok *token.Token) {
 	tok.Type = token.INVALID
 	state, rune1, size := 0, rune(-1), 0
 	for state != -1 {
-		// fmt.Printf("\tpos=%d, line=%d, col=%d, state=%d\n", l.pos, l.line, l.column, state)
 		if l.pos >= len(l.src) {
 			rune1 = -1
 		} else {
 			rune1, size = utf8.DecodeRune(l.src[l.pos:])
 			l.pos += size
 		}
-		// Production start
-		if rune1 != -1 {
-			state = TransTab[state](rune1)
-		} else {
-			state = -1
-		}
-		// Production end
 
-		// Debug start
-		// nextState := -1
-		// if rune1 != -1 {
-		// 	nextState = TransTab[state](rune1)
-		// }
-		// fmt.Printf("\tS%d, : tok=%s, rune == %s(%x), next state == %d\n", state, token.TokMap.Id(tok.Type), util.RuneToString(rune1), rune1, nextState)
-		// fmt.Printf("\t\tpos=%d, size=%d, start=%d, end=%d\n", l.pos, size, start, end)
-		// if nextState != -1 {
-		// 	fmt.Printf("\t\taction:%s\n", ActTab[nextState].String())
-		// }
-		// state = nextState
-		// Debug end
+		nextState := -1
+		if rune1 != -1 {
+			nextState = TransTab[state](rune1)
+		}
+		state = nextState
 
 		if state != -1 {
 
@@ -99,10 +81,8 @@ func (l *Lexer) Scan() (tok *token.Token) {
 			switch {
 			case ActTab[state].Accept != -1:
 				tok.Type = ActTab[state].Accept
-				// fmt.Printf("\t Accept(%s), %s(%d)\n", string(act), token.TokMap.Id(tok), tok)
 				end = l.pos
 			case ActTab[state].Ignore != "":
-				// fmt.Printf("\t Ignore(%s)\n", string(act))
 				start, startLine, startColumn = l.pos, l.line, l.column
 				state = 0
 				if start >= len(l.src) {
@@ -123,7 +103,6 @@ func (l *Lexer) Scan() (tok *token.Token) {
 		tok.Lit = []byte{}
 	}
 	tok.Pos.Offset, tok.Pos.Line, tok.Pos.Column = start, startLine, startColumn
-	// fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
 
 	return
 }

--- a/example/rr/parser/parser.go
+++ b/example/rr/parser/parser.go
@@ -187,7 +187,6 @@ func (p *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 				panic("Error recovery led to invalid action")
 			}
 		}
-		// fmt.Printf("S%d %s %s\n", p.stack.top(), token.TokMap.TokenString(p.nextToken), action)
 
 		switch act := action.(type) {
 		case accept:

--- a/example/sr/lexer/lexer.go
+++ b/example/sr/lexer/lexer.go
@@ -3,11 +3,9 @@
 package lexer
 
 import (
-	// "fmt"
 	"io/ioutil"
 	"unicode/utf8"
 
-	// "github.com/goccmack/gocc/example/sr/util"
 	"github.com/goccmack/gocc/example/sr/token"
 )
 
@@ -43,7 +41,6 @@ func NewLexerFile(fpath string) (*Lexer, error) {
 }
 
 func (l *Lexer) Scan() (tok *token.Token) {
-	// fmt.Printf("Lexer.Scan() pos=%d\n", l.pos)
 	tok = new(token.Token)
 	if l.pos >= len(l.src) {
 		tok.Type = token.EOF
@@ -54,33 +51,18 @@ func (l *Lexer) Scan() (tok *token.Token) {
 	tok.Type = token.INVALID
 	state, rune1, size := 0, rune(-1), 0
 	for state != -1 {
-		// fmt.Printf("\tpos=%d, line=%d, col=%d, state=%d\n", l.pos, l.line, l.column, state)
 		if l.pos >= len(l.src) {
 			rune1 = -1
 		} else {
 			rune1, size = utf8.DecodeRune(l.src[l.pos:])
 			l.pos += size
 		}
-		// Production start
-		if rune1 != -1 {
-			state = TransTab[state](rune1)
-		} else {
-			state = -1
-		}
-		// Production end
 
-		// Debug start
-		// nextState := -1
-		// if rune1 != -1 {
-		// 	nextState = TransTab[state](rune1)
-		// }
-		// fmt.Printf("\tS%d, : tok=%s, rune == %s(%x), next state == %d\n", state, token.TokMap.Id(tok.Type), util.RuneToString(rune1), rune1, nextState)
-		// fmt.Printf("\t\tpos=%d, size=%d, start=%d, end=%d\n", l.pos, size, start, end)
-		// if nextState != -1 {
-		// 	fmt.Printf("\t\taction:%s\n", ActTab[nextState].String())
-		// }
-		// state = nextState
-		// Debug end
+		nextState := -1
+		if rune1 != -1 {
+			nextState = TransTab[state](rune1)
+		}
+		state = nextState
 
 		if state != -1 {
 
@@ -99,10 +81,8 @@ func (l *Lexer) Scan() (tok *token.Token) {
 			switch {
 			case ActTab[state].Accept != -1:
 				tok.Type = ActTab[state].Accept
-				// fmt.Printf("\t Accept(%s), %s(%d)\n", string(act), token.TokMap.Id(tok), tok)
 				end = l.pos
 			case ActTab[state].Ignore != "":
-				// fmt.Printf("\t Ignore(%s)\n", string(act))
 				start, startLine, startColumn = l.pos, l.line, l.column
 				state = 0
 				if start >= len(l.src) {
@@ -123,7 +103,6 @@ func (l *Lexer) Scan() (tok *token.Token) {
 		tok.Lit = []byte{}
 	}
 	tok.Pos.Offset, tok.Pos.Line, tok.Pos.Column = start, startLine, startColumn
-	// fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
 
 	return
 }

--- a/example/sr/parser/parser.go
+++ b/example/sr/parser/parser.go
@@ -187,7 +187,6 @@ func (p *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 				panic("Error recovery led to invalid action")
 			}
 		}
-		// fmt.Printf("S%d %s %s\n", p.stack.top(), token.TokMap.TokenString(p.nextToken), action)
 
 		switch act := action.(type) {
 		case accept:

--- a/internal/lexer/gen/golang/lexer.go
+++ b/internal/lexer/gen/golang/lexer.go
@@ -65,12 +65,12 @@ const lexerSrc string = `
 package lexer
 
 import (
-	{{if .Debug}}"fmt"{{else}}// "fmt"{{end}}
-	"io/ioutil"
+{{if .Debug}}	"fmt"
+{{end}}	"io/ioutil"
 	"unicode/utf8"
 
-	{{if .Debug}}"{{.UtilImport}}"{{else}}// "{{.UtilImport}}"{{end}}
-	"{{.TokenImport}}"
+{{if .Debug}}	"{{.UtilImport}}"
+{{end}}	"{{.TokenImport}}"
 )
 
 const (
@@ -107,8 +107,6 @@ func NewLexerFile(fpath string) (*Lexer, error) {
 func (l *Lexer) Scan() (tok *token.Token) {
 	{{- if .Debug}}
 	fmt.Printf("Lexer.Scan() pos=%d\n", l.pos)
-	{{- else}}
-	// fmt.Printf("Lexer.Scan() pos=%d\n", l.pos)
 	{{- end}}
 	tok = new(token.Token)
 	if l.pos >= len(l.src) {
@@ -120,11 +118,9 @@ func (l *Lexer) Scan() (tok *token.Token) {
 	tok.Type = token.INVALID
 	state, rune1, size := 0, rune(-1), 0
 	for state != -1 {
-	{{- if .Debug}}
+		{{- if .Debug}}
 		fmt.Printf("\tpos=%d, line=%d, col=%d, state=%d\n", l.pos, l.line, l.column, state)
-	{{- else}}
-		// fmt.Printf("\tpos=%d, line=%d, col=%d, state=%d\n", l.pos, l.line, l.column, state)
-	{{- end}}
+		{{- end}}
 		if l.pos >= len(l.src) {
 			rune1 = -1
 		} else {
@@ -132,49 +128,18 @@ func (l *Lexer) Scan() (tok *token.Token) {
 			l.pos += size
 		}
 
-	{{- if .Debug}}
-		// Production start
-		// if rune1 != -1 {
-		// 	state = TransTab[state](rune1)
-		// } else {
-		// 	state = -1
-		// }
-		// Production end
-
-		// Debug start
 		nextState := -1
 		if rune1 != -1 {
 			nextState = TransTab[state](rune1)
 		}
+		{{- if .Debug}}
 		fmt.Printf("\tS%d, : tok=%s, rune == %s(%x), next state == %d\n", state, token.TokMap.Id(tok.Type), util.RuneToString(rune1), rune1, nextState)
 		fmt.Printf("\t\tpos=%d, size=%d, start=%d, end=%d\n", l.pos, size, start, end)
 		if nextState != -1 {
 			fmt.Printf("\t\taction:%s\n", ActTab[nextState].String())
 		}
+		{{- end}}
 		state = nextState
-		// Debug end
-	{{- else}}
-		// Production start
-		if rune1 != -1 {
-			state = TransTab[state](rune1)
-		} else {
-			state = -1
-		}
-		// Production end
-
-		// Debug start
-		// nextState := -1
-		// if rune1 != -1 {
-		// 	nextState = TransTab[state](rune1)
-		// }
-		// fmt.Printf("\tS%d, : tok=%s, rune == %s(%x), next state == %d\n", state, token.TokMap.Id(tok.Type), util.RuneToString(rune1), rune1, nextState)
-		// fmt.Printf("\t\tpos=%d, size=%d, start=%d, end=%d\n", l.pos, size, start, end)
-		// if nextState != -1 {
-		// 	fmt.Printf("\t\taction:%s\n", ActTab[nextState].String())
-		// }
-		// state = nextState
-		// Debug end
-	{{- end}}
 
 		if state != -1 {
 
@@ -193,10 +158,8 @@ func (l *Lexer) Scan() (tok *token.Token) {
 			switch {
 			case ActTab[state].Accept != -1:
 				tok.Type = ActTab[state].Accept
-				// fmt.Printf("\t Accept(%s), %s(%d)\n", string(act), token.TokMap.Id(tok), tok)
 				end = l.pos
 			case ActTab[state].Ignore != "":
-				// fmt.Printf("\t Ignore(%s)\n", string(act))
 				start, startLine, startColumn = l.pos, l.line, l.column
 				state = 0
 				if start >= len(l.src) {
@@ -220,8 +183,6 @@ func (l *Lexer) Scan() (tok *token.Token) {
 
 	{{- if .Debug}}
 	fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
-	{{- else}}
-	// fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
 	{{- end}}
 
 	return

--- a/internal/parser/gen/golang/parser.go
+++ b/internal/parser/gen/golang/parser.go
@@ -250,8 +250,6 @@ func (p *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 		}
 		{{- if .Debug }}
 		fmt.Printf("S%d %s %s\n", p.stack.top(), token.TokMap.TokenString(p.nextToken), action)
-		{{- else }}
-		// fmt.Printf("S%d %s %s\n", p.stack.top(), token.TokMap.TokenString(p.nextToken), action)
 		{{- end }}
 
 		switch act := action.(type) {

--- a/internal/test/t1/lexer/lexer.go
+++ b/internal/test/t1/lexer/lexer.go
@@ -3,11 +3,9 @@
 package lexer
 
 import (
-	// "fmt"
 	"io/ioutil"
 	"unicode/utf8"
 
-	// "github.com/goccmack/gocc/internal/test/t1/util"
 	"github.com/goccmack/gocc/internal/test/t1/token"
 )
 
@@ -43,7 +41,6 @@ func NewLexerFile(fpath string) (*Lexer, error) {
 }
 
 func (l *Lexer) Scan() (tok *token.Token) {
-	// fmt.Printf("Lexer.Scan() pos=%d\n", l.pos)
 	tok = new(token.Token)
 	if l.pos >= len(l.src) {
 		tok.Type = token.EOF
@@ -54,33 +51,18 @@ func (l *Lexer) Scan() (tok *token.Token) {
 	tok.Type = token.INVALID
 	state, rune1, size := 0, rune(-1), 0
 	for state != -1 {
-		// fmt.Printf("\tpos=%d, line=%d, col=%d, state=%d\n", l.pos, l.line, l.column, state)
 		if l.pos >= len(l.src) {
 			rune1 = -1
 		} else {
 			rune1, size = utf8.DecodeRune(l.src[l.pos:])
 			l.pos += size
 		}
-		// Production start
-		if rune1 != -1 {
-			state = TransTab[state](rune1)
-		} else {
-			state = -1
-		}
-		// Production end
 
-		// Debug start
-		// nextState := -1
-		// if rune1 != -1 {
-		// 	nextState = TransTab[state](rune1)
-		// }
-		// fmt.Printf("\tS%d, : tok=%s, rune == %s(%x), next state == %d\n", state, token.TokMap.Id(tok.Type), util.RuneToString(rune1), rune1, nextState)
-		// fmt.Printf("\t\tpos=%d, size=%d, start=%d, end=%d\n", l.pos, size, start, end)
-		// if nextState != -1 {
-		// 	fmt.Printf("\t\taction:%s\n", ActTab[nextState].String())
-		// }
-		// state = nextState
-		// Debug end
+		nextState := -1
+		if rune1 != -1 {
+			nextState = TransTab[state](rune1)
+		}
+		state = nextState
 
 		if state != -1 {
 
@@ -99,10 +81,8 @@ func (l *Lexer) Scan() (tok *token.Token) {
 			switch {
 			case ActTab[state].Accept != -1:
 				tok.Type = ActTab[state].Accept
-				// fmt.Printf("\t Accept(%s), %s(%d)\n", string(act), token.TokMap.Id(tok), tok)
 				end = l.pos
 			case ActTab[state].Ignore != "":
-				// fmt.Printf("\t Ignore(%s)\n", string(act))
 				start, startLine, startColumn = l.pos, l.line, l.column
 				state = 0
 				if start >= len(l.src) {
@@ -123,7 +103,6 @@ func (l *Lexer) Scan() (tok *token.Token) {
 		tok.Lit = []byte{}
 	}
 	tok.Pos.Offset, tok.Pos.Line, tok.Pos.Column = start, startLine, startColumn
-	// fmt.Printf("Token at %s: %s \"%s\"\n", tok.String(), token.TokMap.Id(tok.Type), tok.Lit)
 
 	return
 }

--- a/internal/test/t1/parser/parser.go
+++ b/internal/test/t1/parser/parser.go
@@ -187,7 +187,6 @@ func (p *Parser) Parse(scanner Scanner) (res interface{}, err error) {
 				panic("Error recovery led to invalid action")
 			}
 		}
-		// fmt.Printf("S%d %s %s\n", p.stack.top(), token.TokMap.TokenString(p.nextToken), action)
 
 		switch act := action.(type) {
 		case accept:


### PR DESCRIPTION
Removes commented out prints for debug purposes from production code and removes
depricated debug printouts generated from lexer.go and parser.go.

Also fixes minor issues in template code for gofmt complience.

Fixes #53.