### PR TITLE
Add -profile option, remove unnecessary type conversion and output more detailed error messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 script:
   - echo $TRAVIS_GO_VERSION
   - PATH=/home/travis/bin:$PATH make travis
-  
+
 language: go
 
 go:
-  - 1.6.3
-  - 1.7.1
+  - 1.8.7
+  - 1.9.4
+  - 1.10.0

--- a/example/astx/errors/errors.go
+++ b/example/astx/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, e.Err.Error())
+		fmt.Fprintf(w, "%+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/astx/parser/parser.go
+++ b/example/astx/parser/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Error(err error, scanner Scanner) (recovered bool, errorAttrib 
 
 func (p *Parser) popNonRecoveryStates() (removedAttribs []parseError.ErrorSymbol) {
 	if rs, ok := p.firstRecoveryState(); ok {
-		errorSymbols := p.stack.popN(int(p.stack.topIndex() - rs))
+		errorSymbols := p.stack.popN(p.stack.topIndex() - rs)
 		removedAttribs = make([]parseError.ErrorSymbol, len(errorSymbols))
 		for i, e := range errorSymbols {
 			removedAttribs[i] = e

--- a/example/bools/errors/errors.go
+++ b/example/bools/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, e.Err.Error())
+		fmt.Fprintf(w, "%+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/bools/parser/parser.go
+++ b/example/bools/parser/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Error(err error, scanner Scanner) (recovered bool, errorAttrib 
 
 func (p *Parser) popNonRecoveryStates() (removedAttribs []parseError.ErrorSymbol) {
 	if rs, ok := p.firstRecoveryState(); ok {
-		errorSymbols := p.stack.popN(int(p.stack.topIndex() - rs))
+		errorSymbols := p.stack.popN(p.stack.topIndex() - rs)
 		removedAttribs = make([]parseError.ErrorSymbol, len(errorSymbols))
 		for i, e := range errorSymbols {
 			removedAttribs[i] = e

--- a/example/calc/errors/errors.go
+++ b/example/calc/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, e.Err.Error())
+		fmt.Fprintf(w, "%+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/calc/parser/parser.go
+++ b/example/calc/parser/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Error(err error, scanner Scanner) (recovered bool, errorAttrib 
 
 func (p *Parser) popNonRecoveryStates() (removedAttribs []parseError.ErrorSymbol) {
 	if rs, ok := p.firstRecoveryState(); ok {
-		errorSymbols := p.stack.popN(int(p.stack.topIndex() - rs))
+		errorSymbols := p.stack.popN(p.stack.topIndex() - rs)
 		removedAttribs = make([]parseError.ErrorSymbol, len(errorSymbols))
 		for i, e := range errorSymbols {
 			removedAttribs[i] = e

--- a/example/errorrecovery/errors/errors.go
+++ b/example/errorrecovery/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, e.Err.Error())
+		fmt.Fprintf(w, "%+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/errorrecovery/parser/parser.go
+++ b/example/errorrecovery/parser/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Error(err error, scanner Scanner) (recovered bool, errorAttrib 
 
 func (p *Parser) popNonRecoveryStates() (removedAttribs []parseError.ErrorSymbol) {
 	if rs, ok := p.firstRecoveryState(); ok {
-		errorSymbols := p.stack.popN(int(p.stack.topIndex() - rs))
+		errorSymbols := p.stack.popN(p.stack.topIndex() - rs)
 		removedAttribs = make([]parseError.ErrorSymbol, len(errorSymbols))
 		for i, e := range errorSymbols {
 			removedAttribs[i] = e

--- a/example/nolexer/errors/errors.go
+++ b/example/nolexer/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, e.Err.Error())
+		fmt.Fprintf(w, "%+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/nolexer/parser/parser.go
+++ b/example/nolexer/parser/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Error(err error, scanner Scanner) (recovered bool, errorAttrib 
 
 func (p *Parser) popNonRecoveryStates() (removedAttribs []parseError.ErrorSymbol) {
 	if rs, ok := p.firstRecoveryState(); ok {
-		errorSymbols := p.stack.popN(int(p.stack.topIndex() - rs))
+		errorSymbols := p.stack.popN(p.stack.topIndex() - rs)
 		removedAttribs = make([]parseError.ErrorSymbol, len(errorSymbols))
 		for i, e := range errorSymbols {
 			removedAttribs[i] = e

--- a/example/rr/errors/errors.go
+++ b/example/rr/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, e.Err.Error())
+		fmt.Fprintf(w, "%+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/rr/parser/parser.go
+++ b/example/rr/parser/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Error(err error, scanner Scanner) (recovered bool, errorAttrib 
 
 func (p *Parser) popNonRecoveryStates() (removedAttribs []parseError.ErrorSymbol) {
 	if rs, ok := p.firstRecoveryState(); ok {
-		errorSymbols := p.stack.popN(int(p.stack.topIndex() - rs))
+		errorSymbols := p.stack.popN(p.stack.topIndex() - rs)
 		removedAttribs = make([]parseError.ErrorSymbol, len(errorSymbols))
 		for i, e := range errorSymbols {
 			removedAttribs[i] = e

--- a/example/sr/errors/errors.go
+++ b/example/sr/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, e.Err.Error())
+		fmt.Fprintf(w, "%+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/sr/parser/parser.go
+++ b/example/sr/parser/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Error(err error, scanner Scanner) (recovered bool, errorAttrib 
 
 func (p *Parser) popNonRecoveryStates() (removedAttribs []parseError.ErrorSymbol) {
 	if rs, ok := p.firstRecoveryState(); ok {
-		errorSymbols := p.stack.popN(int(p.stack.topIndex() - rs))
+		errorSymbols := p.stack.popN(p.stack.topIndex() - rs)
 		removedAttribs = make([]parseError.ErrorSymbol, len(errorSymbols))
 		for i, e := range errorSymbols {
 			removedAttribs[i] = e

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ type Config interface {
 	Zip() bool
 	AllowUnreachable() bool
 	AutoResolveLRConf() bool
-	// Profile() bool
+	Profile() bool
 	SourceFile() string
 	OutDir() string
 
@@ -61,10 +61,10 @@ type ConfigRecord struct {
 	noLexer           *bool
 	outDir            string
 	pkg               string
-	// profile           *bool
-	srcFile string
-	verbose *bool
-	zip     *bool
+	profile           *bool
+	srcFile           string
+	verbose           *bool
+	zip               *bool
 }
 
 func New() (Config, error) {
@@ -117,9 +117,9 @@ func (this *ConfigRecord) DebugParser() bool {
 	return *this.debugParser
 }
 
-// func (this *ConfigRecord) Profile() bool {
-// 	return *this.profile
-// }
+func (this *ConfigRecord) Profile() bool {
+	return *this.profile
+}
 
 func (this *ConfigRecord) SourceFile() string {
 	return this.srcFile
@@ -162,9 +162,10 @@ func (this *ConfigRecord) PrintParams() {
 	fmt.Printf("-no_lexer      = %v\n", *this.noLexer)
 	fmt.Printf("-o             = %v\n", this.outDir)
 	fmt.Printf("-p             = %v\n", this.pkg)
+	fmt.Printf("-profile       = %v\n", *this.profile)
 	fmt.Printf("-u             = %v\n", *this.allowUnreachable)
 	fmt.Printf("-v             = %v\n", *this.verbose)
-	fmt.Printf("-zip          = %v\n", *this.zip)
+	fmt.Printf("-zip           = %v\n", *this.zip)
 }
 
 /*** Utility routines ***/
@@ -177,6 +178,7 @@ func (this *ConfigRecord) getFlags() error {
 	this.noLexer = flag.Bool("no_lexer", false, "do not generate a lexer")
 	flag.StringVar(&this.outDir, "o", this.workingDir, "output dir.")
 	flag.StringVar(&this.pkg, "p", defaultPackage(this.outDir), "package")
+	this.profile = flag.Bool("profile", false, "enable profiling")
 	this.allowUnreachable = flag.Bool("u", false, "allow unreachable productions")
 	this.verbose = flag.Bool("v", false, "verbose")
 	this.zip = flag.Bool("zip", false, "zip the actiontable and gototable (experimental)")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,6 @@ type Config interface {
 	Zip() bool
 	AllowUnreachable() bool
 	AutoResolveLRConf() bool
-	Profile() bool
 	SourceFile() string
 	OutDir() string
 
@@ -61,7 +60,6 @@ type ConfigRecord struct {
 	noLexer           *bool
 	outDir            string
 	pkg               string
-	profile           *bool
 	srcFile           string
 	verbose           *bool
 	zip               *bool
@@ -117,10 +115,6 @@ func (this *ConfigRecord) DebugParser() bool {
 	return *this.debugParser
 }
 
-func (this *ConfigRecord) Profile() bool {
-	return *this.profile
-}
-
 func (this *ConfigRecord) SourceFile() string {
 	return this.srcFile
 }
@@ -162,7 +156,6 @@ func (this *ConfigRecord) PrintParams() {
 	fmt.Printf("-no_lexer      = %v\n", *this.noLexer)
 	fmt.Printf("-o             = %v\n", this.outDir)
 	fmt.Printf("-p             = %v\n", this.pkg)
-	fmt.Printf("-profile       = %v\n", *this.profile)
 	fmt.Printf("-u             = %v\n", *this.allowUnreachable)
 	fmt.Printf("-v             = %v\n", *this.verbose)
 	fmt.Printf("-zip           = %v\n", *this.zip)
@@ -178,7 +171,6 @@ func (this *ConfigRecord) getFlags() error {
 	this.noLexer = flag.Bool("no_lexer", false, "do not generate a lexer")
 	flag.StringVar(&this.outDir, "o", this.workingDir, "output dir.")
 	flag.StringVar(&this.pkg, "p", defaultPackage(this.outDir), "package")
-	this.profile = flag.Bool("profile", false, "enable profiling")
 	this.allowUnreachable = flag.Bool("u", false, "allow unreachable productions")
 	this.verbose = flag.Bool("v", false, "verbose")
 	this.zip = flag.Bool("zip", false, "zip the actiontable and gototable (experimental)")

--- a/internal/parser/gen/golang/errors.go
+++ b/internal/parser/gen/golang/errors.go
@@ -81,7 +81,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, e.Err.Error())
+		fmt.Fprintf(w, "%+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/internal/parser/gen/golang/parser.go
+++ b/internal/parser/gen/golang/parser.go
@@ -198,7 +198,7 @@ func (p *Parser) Error(err error, scanner Scanner) (recovered bool, errorAttrib 
 
 func (p *Parser) popNonRecoveryStates() (removedAttribs []parseError.ErrorSymbol) {
 	if rs, ok := p.firstRecoveryState(); ok {
-		errorSymbols := p.stack.popN(int(p.stack.topIndex() - rs))
+		errorSymbols := p.stack.popN(p.stack.topIndex() - rs)
 		removedAttribs = make([]parseError.ErrorSymbol, len(errorSymbols))
 		for i, e := range errorSymbols {
 			removedAttribs[i] = e

--- a/internal/test/t1/errors/errors.go
+++ b/internal/test/t1/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, e.Err.Error())
+		fmt.Fprintf(w, "%+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/internal/test/t1/parser/parser.go
+++ b/internal/test/t1/parser/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Error(err error, scanner Scanner) (recovered bool, errorAttrib 
 
 func (p *Parser) popNonRecoveryStates() (removedAttribs []parseError.ErrorSymbol) {
 	if rs, ok := p.firstRecoveryState(); ok {
-		errorSymbols := p.stack.popN(int(p.stack.topIndex() - rs))
+		errorSymbols := p.stack.popN(p.stack.topIndex() - rs)
 		removedAttribs = make([]parseError.ErrorSymbol, len(errorSymbols))
 		for i, e := range errorSymbols {
 			removedAttribs[i] = e

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime/pprof"
 
 	"github.com/goccmack/gocc/internal/ast"
 	"github.com/goccmack/gocc/internal/config"
@@ -64,10 +65,10 @@ func main() {
 		flag.Usage()
 	}
 
-	// if *profile {
-	// 	startProfiler()
-	// 	defer pprof.StopCPUProfile()
-	// }
+	if cfg.Profile() {
+		startProfiler()
+		defer pprof.StopCPUProfile()
+	}
 
 	scanner := &scanner.Scanner{}
 	srcBuffer, err := ioutil.ReadFile(cfg.SourceFile())
@@ -193,11 +194,11 @@ func writeTerminals(gSymbols *symbols.Symbols, cfg config.Config) {
 	io.WriteFile(path.Join(cfg.OutDir(), "terminals.txt"), buf.Bytes())
 }
 
-// func startProfiler() {
-// 	f, err := os.Create("cpu.prof")
-// 	if err != nil {
-// 		fmt.Fprintf(os.Stderr, "ABORT: cannot create cpu profile file, \"%s\"\n", err)
-// 		os.Exit(1)
-// 	}
-// 	pprof.StartCPUProfile(f)
-// }
+func startProfiler() {
+	f, err := os.Create("cpu.prof")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ABORT: cannot create cpu profile file, \"%s\"\n", err)
+		os.Exit(1)
+	}
+	pprof.StartCPUProfile(f)
+}

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"runtime/pprof"
 
 	"github.com/goccmack/gocc/internal/ast"
 	"github.com/goccmack/gocc/internal/config"
@@ -63,11 +62,6 @@ func main() {
 
 	if cfg.Help() {
 		flag.Usage()
-	}
-
-	if cfg.Profile() {
-		startProfiler()
-		defer pprof.StopCPUProfile()
 	}
 
 	scanner := &scanner.Scanner{}
@@ -192,13 +186,4 @@ func writeTerminals(gSymbols *symbols.Symbols, cfg config.Config) {
 		fmt.Fprintf(buf, "%s\n", t)
 	}
 	io.WriteFile(path.Join(cfg.OutDir(), "terminals.txt"), buf.Bytes())
-}
-
-func startProfiler() {
-	f, err := os.Create("cpu.prof")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ABORT: cannot create cpu profile file, \"%s\"\n", err)
-		os.Exit(1)
-	}
-	pprof.StartCPUProfile(f)
 }


### PR DESCRIPTION
The `-profile` option was present before but has since been commented out, add the option back to enable profiling of gocc.

An unnecessary type conversion was located by unconvert in the generated code of `parser/parser.go`

```diff
-               errorSymbols := p.stack.popN(int(p.stack.topIndex() - rs))
+               errorSymbols := p.stack.popN(p.stack.topIndex() - rs)
```

Last but not least, change the error handling so that extended error values don't lose extra information when reporting errors. For instance, using errors from the [errors](https://github.com/pkg/errors) now reports the full context of the error.