### PR TITLE
Update verbosity when LR-1 conflicts are encountered

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,14 +141,13 @@ func handleConflicts(conflicts map[int]lr1Items.RowConflicts, numSets int, cfg c
 	if len(conflicts) <= 0 {
 		return
 	}
-	switch {
-	case !cfg.AutoResolveLRConf():
-		fmt.Printf("Error: %d LR-1 conflicts\n", len(conflicts))
-		io.WriteFileString(path.Join(cfg.OutDir(), "LR1_conflicts.txt"), conflictString(conflicts, numSets, prods))
-		os.Exit(1)
-	case cfg.Verbose():
+	if cfg.Verbose() {
 		fmt.Printf("%d LR-1 conflicts \n", len(conflicts))
 		io.WriteFileString(path.Join(cfg.OutDir(), "LR1_conflicts.txt"), conflictString(conflicts, numSets, prods))
+	}
+	if !cfg.AutoResolveLRConf() {
+		fmt.Printf("Error: %d LR-1 conflicts \n", len(conflicts))
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
In case of LR-1 conflicts, the files `LR1_conflicts.txt` and `LR1_sets.txt` will be generated only when `-v` option is provided during invocation. Else, only the number of conflicts will be reported.