### PR TITLE
Pretty-print errors, making them more readable

### DIFF
--- a/example/astx/errors/errors.go
+++ b/example/astx/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, "%+v", e.Err)
+		fmt.Fprintf(w, ": %+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/bools/errors/errors.go
+++ b/example/bools/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, "%+v", e.Err)
+		fmt.Fprintf(w, ": %+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/calc/errors/errors.go
+++ b/example/calc/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, "%+v", e.Err)
+		fmt.Fprintf(w, ": %+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/errorrecovery/errors/errors.go
+++ b/example/errorrecovery/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, "%+v", e.Err)
+		fmt.Fprintf(w, ": %+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/nolexer/errors/errors.go
+++ b/example/nolexer/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, "%+v", e.Err)
+		fmt.Fprintf(w, ": %+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/rr/errors/errors.go
+++ b/example/rr/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, "%+v", e.Err)
+		fmt.Fprintf(w, ": %+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/example/sr/errors/errors.go
+++ b/example/sr/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, "%+v", e.Err)
+		fmt.Fprintf(w, ": %+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/internal/parser/gen/golang/errors.go
+++ b/internal/parser/gen/golang/errors.go
@@ -81,7 +81,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, "%+v", e.Err)
+		fmt.Fprintf(w, ": %+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {

--- a/internal/test/t1/errors/errors.go
+++ b/internal/test/t1/errors/errors.go
@@ -45,7 +45,7 @@ func (e *Error) Error() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "Error in S%d: %s, %s", e.StackTop, token.TokMap.TokenString(e.ErrorToken), e.ErrorToken.Pos.String())
 	if e.Err != nil {
-		fmt.Fprintf(w, "%+v", e.Err)
+		fmt.Fprintf(w, ": %+v", e.Err)
 	} else {
 		fmt.Fprintf(w, ", expected one of: ")
 		for _, expected := range e.ExpectedTokens {


### PR DESCRIPTION
**Before**
Error in S90: =(4,=), Pos(offset=239, line=9, column=7)undefined: a

**After**
Error in S90: =(4,=), Pos(offset=239, line=9, column=7): undefined: a