### PR TITLE
main: Refactor global declaration of config variable into a local one

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,15 +45,12 @@ import (
 	genParser "github.com/goccmack/gocc/internal/parser/gen"
 )
 
-var cfg config.Config
-
 func main() {
 	flag.Usage = usage
-	if cfg1, err := config.New(); err != nil {
+	cfg, err := config.New()
+	if err != nil {
 		fmt.Printf("Error reading configuration: %s\n", err)
 		flag.Usage()
-	} else {
-		cfg = cfg1
 	}
 
 	if cfg.Verbose() {


### PR DESCRIPTION
I couldn't find any utility of declaring `cfg` globally, it's possible I might've missed something.