### PR TITLE
improvement: make generated code safer

### DIFF
--- a/internal/parser/gen/golang/actiontable.go
+++ b/internal/parser/gen/golang/actiontable.go
@@ -115,21 +115,30 @@ func getActionRowData(prods ast.SyntaxProdList, set *items.ItemSet, tokMap *toke
 		switch act1 := act.(type) {
 		case action.Accept:
 			pad := max + 1 - len("accept(true),")
-			data.Actions[i] = fmt.Sprintf("accept(true),%*c/* %s */", pad, ' ', sym)
+			data.Actions[i] = fmt.Sprintf("accept(true),%*c/* %s */", pad, ' ', safeSym(sym))
 		case action.Error:
 			pad := max + 1 - len("nil,")
-			data.Actions[i] = fmt.Sprintf("nil,%*c/* %s */", pad, ' ', sym)
+			data.Actions[i] = fmt.Sprintf("nil,%*c/* %s */", pad, ' ', safeSym(sym))
 		case action.Reduce:
 			pad := max + 1 - (len("reduce(") + nbytes(int(act1)) + len("),"))
-			data.Actions[i] = fmt.Sprintf("reduce(%d),%*c/* %s, reduce: %s */", int(act1), pad, ' ', sym, prods[int(act1)].Id)
+			data.Actions[i] = fmt.Sprintf("reduce(%d),%*c/* %s, reduce: %s */", int(act1), pad, ' ', safeSym(sym), prods[int(act1)].Id)
 		case action.Shift:
 			pad := max + 1 - (len("shift(") + nbytes(int(act1)) + len("),"))
-			data.Actions[i] = fmt.Sprintf("shift(%d),%*c/* %s */", int(act1), pad, ' ', sym)
+			data.Actions[i] = fmt.Sprintf("shift(%d),%*c/* %s */", int(act1), pad, ' ', safeSym(sym))
 		default:
 			panic(fmt.Sprintf("Unknown action type: %T", act1))
 		}
 	}
 	return
+}
+
+func safeSym(sym string) string {
+	switch sym {
+	case `*/`:
+		return "special case: closing multiline comment sequence"
+	}
+
+	return sym
 }
 
 const actionTableSrc = `

--- a/internal/parser/gen/golang/actiontable.go
+++ b/internal/parser/gen/golang/actiontable.go
@@ -134,6 +134,7 @@ func getActionRowData(prods ast.SyntaxProdList, set *items.ItemSet, tokMap *toke
 
 func safeSym(sym string) string {
 	switch sym {
+	// avoid `/* */ */` comment causing compilation error
 	case `*/`:
 		return "special case: closing multiline comment sequence"
 	}

--- a/internal/token/gen/golang/token.go
+++ b/internal/token/gen/golang/token.go
@@ -107,7 +107,7 @@ func (m TokenMap) Type(tok string) Type {
 
 func (m TokenMap) TokenString(tok *Token) string {
 	//TODO: refactor to print pos & token string properly
-	return fmt.Sprintf("%s(%d,%s)", m.Id(tok.Type), tok.Type, tok.Lit)
+	return fmt.Sprintf("%s(%d,%q)", m.Id(tok.Type), tok.Type, tok.Lit)
 }
 
 func (m TokenMap) StringType(typ Type) string {


### PR DESCRIPTION
how to reproduce a _closing multiline comment sequence_ problem

```
mkdir mlcomment-test
cd mlcomment-test
go mod init github.com/goccmack/gocc/mlcomment-test
echo 'MLComment: "/*" "test" "*/";' > mlcomment-test.ebnf
gocc -a -v -p github.com/goccmack/gocc/mlcomment-test mlcomment-test.ebnf
go build ./parser
```