### PR TITLE
travis: disable go1.10 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ script:
 language: go
 
 go:
-  - 1.10.x
   - 1.11.x
   - 1.12.x


### PR DESCRIPTION
This is a temporary workaround for build failures on go1.10 due to
errcheck.