### PR TITLE
Bugfix for finding default package when using go-modules mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,7 +212,7 @@ func getOutDir(outDirSpec, wd string) string {
 
 func defaultPackage(wd string) (string, error) {
 	pkg, parent, err := currentModule()
-	if err != nil {
+	if err == nil {
 		pkg = pkg + strings.TrimPrefix(wd, parent)
 		return pkg, nil
 	}


### PR DESCRIPTION
When switching [Miller](https://github.com/johnkerl/miller) over to use Go modules, I ran into this issue.