### PR TITLE
Expose sdt elements as *token.Token with `$T0` etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ An action expression is specified as "<", "<", goccExpressionList , ">", ">" . T
 type Attrib interface {}
 ```
 
-Also parsed elements of the corresponding bnf rule can be represented in the expressionList as "$", digit.
+Also, parsed elements of the corresponding bnf rule can be represented in the expressionList as "$", digit.
 
 Some action expression examples:
 
@@ -148,6 +148,13 @@ Some action expression examples:
 ```
 
 Contants, functions, etc. that are returned or called should be programmed by the user in his ast (Abstract Syntax Tree) package. The ast package requires that you define your own Attrib interface as shown above. All parameters passed to functions will be of this type.
+
+For raw elements that you know to be a `*token.Token`, you can use the short-hand: `$T0` etc, leading the following expressions to produce identical results:
+
+```
+<< $3.(*token.Token), nil >>
+<< $T3, nil >>
+```
 
 Some example of functions:
 

--- a/doc/gocc_user_guide.tex
+++ b/doc/gocc_user_guide.tex
@@ -308,10 +308,10 @@
 			\item Each alternative of a production may optionally have an action expression. E.g.:
 
 			\begin{verbatim}
-				Factor : int64                 << util.IntValue($0.(*token.Token).Lit) >>
+				Factor : int64                 << util.IntValue($T0.Lit) >>
 			\end{verbatim}
 
-			has an action expression, \verb|<< util.IntValue($0.(*token.Token).Lit) >>|, which contains a call to the function, IntValue, in the generated file util/litconv.go. Attribute \verb|$0|, associated with the symbol \verb|int64| in the body of the production, is type asserted to \verb|*token.Token|, of which the field \verb|Lit| is passed as parameter to the function.
+			has an action expression, \verb|<< util.IntValue($T0.Lit) >>|, which contains a call to the function, IntValue, in the generated file util/litconv.go. Attribute \verb|$T0|, associated with the symbol \verb|int64| in the body of the production, is type asserted to \verb|*token.Token|, of which the field \verb|Lit| is passed as parameter to the function.
 			Action expressions must always return a value of type, \verb|(interface{}, error)|. If the returned error parameter is \verb|nil|, the \verb|interface{}| parameter is placed on the parser stack as the attribute of the recognised production.
 
 			\item Each recognised term in a production has an associated attribute. For example: the production alternative:
@@ -324,6 +324,8 @@
 
 			The action expression in this example means the following: {\em return the product of \$0 and \$2, both cast to type \verb|int64|, together with \verb|nil|.}
 		\end{enumerate}
+
+			If an attribute is known to be a \verb|*token.Token| they can be referenced through the shorthand syntax, \$T0, \$T1 and \$T2, respectively. Note, you will need to import the token package.
 
 		When the parser has recognised the whole body of a production alternative, it calls the associated action expression with the attributes of the recognised language symbols of that body. If the action expression returns a non-nil error the parser stops and returns the error to the calling user application. If the action expression returns a nil error the parser replaces the recognised language symbols of the production on its stack with the attribute returned by the action expression.
 
@@ -707,7 +709,10 @@ Error: 1 LR-1 conflicts
 	The grammar is in \verb|ast.bnf|:
 
 	\begin{verbatim}
-		<< import "github.com/goccmack/gocc/example/astx/ast" >>
+		<<
+		import "github.com/goccmack/gocc/example/astx/ast"
+		import "github.com/goccmack/gocc/example/astx/token"
+		>>
 
 		StmtList :
 		      Stmt             << ast.NewStmtList($0) >>
@@ -715,7 +720,7 @@ Error: 1 LR-1 conflicts
 		;
 
 		Stmt :
-		      id               << ast.NewStmt($0) >>
+		      id               << ast.NewStmt($T0) >>
 		;
 	\end{verbatim}
 
@@ -749,8 +754,9 @@ Error: 1 LR-1 conflicts
 		    return append(stmtList.(StmtList), stmt.(Stmt)), nil
 		}
 
-		func NewStmt(stmtList interface{}) (Stmt, error) {
-		    return Stmt(stmtList.(*token.Token).Lit), nil
+		// stmtList is passed using $T0.
+		func NewStmt(stmtList *token.Token) (Stmt, error) {
+		    return Stmt(stmtList.Lit), nil
 		}
 	\end{verbatim}
 

--- a/example/astx/ast.bnf
+++ b/example/astx/ast.bnf
@@ -12,7 +12,10 @@ id : (_letter | '_') {_idchar} ;
 
 /* Syntax elements */
 
-<< import "github.com/goccmack/gocc/example/astx/ast" >>
+<<
+import "github.com/goccmack/gocc/example/astx/ast"
+import "github.com/goccmack/gocc/example/astx/token"
+>>
 
 StmtList : 
       Stmt             << ast.NewStmtList($0) >>
@@ -20,5 +23,5 @@ StmtList :
 ;
 
 Stmt : 
-      id               << ast.NewStmt($0) >>
+      id               << ast.NewStmt($T0) >>
 ;

--- a/example/astx/ast/ast.go
+++ b/example/astx/ast/ast.go
@@ -17,6 +17,7 @@ func AppendStmt(stmtList, stmt interface{}) (StmtList, error) {
 	return append(stmtList.(StmtList), stmt.(Stmt)), nil
 }
 
-func NewStmt(stmtList interface{}) (Stmt, error) {
-	return Stmt(stmtList.(*token.Token).Lit), nil
+// stmtList is passed using $T0.
+func NewStmt(stmtList *token.Token) (Stmt, error) {
+	return Stmt(stmtList.Lit), nil
 }

--- a/example/astx/parser/productionstable.go
+++ b/example/astx/parser/productionstable.go
@@ -2,7 +2,10 @@
 
 package parser
 
-import "github.com/goccmack/gocc/example/astx/ast"
+import (
+	"github.com/goccmack/gocc/example/astx/ast"
+	"github.com/goccmack/gocc/example/astx/token"
+)
 
 type (
 	ProdTab      [numProductions]ProdTabEntry
@@ -50,13 +53,13 @@ var productionsTable = ProdTab{
 		},
 	},
 	ProdTabEntry{
-		String: `Stmt : id	<< ast.NewStmt(X[0]) >>`,
+		String: `Stmt : id	<< ast.NewStmt(X[0].(*token.Token)) >>`,
 		Id:         "Stmt",
 		NTType:     2,
 		Index:      3,
 		NumSymbols: 1,
 		ReduceFunc: func(X []Attrib) (Attrib, error) {
-			return ast.NewStmt(X[0])
+			return ast.NewStmt(X[0].(*token.Token))
 		},
 	},
 }


### PR DESCRIPTION
My code routinely makes use of raw tokens, which adds a LOT of boiler plate in
translating these tokens from Attrib to *token.Token; either the BNF becomes a
hideous mess of casts, or many of the most trivial functions are cluttered
with them.

This change:
- compiles the sdt regex once, on startup, rather than per action,
- streamlines/simplifies code by using ReplaceAllString,
(* if ReplaceAllString is more expensive than prior code, the one-time
expression compile pays for it)
- allows `$T0`, ... `$T9999` etc as producing X[n].(*token.Token),
- uses example/astx to demonstrate/test,
- updates the documentation to reflect,