### PR TITLE
Normalize editing configurations and line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = false
+end_of_line = lf
+
+[*.{go,bnf,tex}]
+charset = utf-8
+
+[{*.{yml,yaml}]
+indent_size = 2
+indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+*.go        text eol=lf
+*.bnf       text eol=lf
+*.md        text eol=lf
+*.txt       text eol=lf
+*.tex       text eol=lf
+*.sh        text eol=lf
+
+Makefile    text eol=lf
+LICENSE     text eol=lf
+
+*.pdf       -text
+*.jpg       -text


### PR DESCRIPTION
These changes are intended to ensure that people working across different
IDEs and editors have the greatest chance of not introducing whitespace
or encoding changes in their PRs. The gitattributes addition is based on
my cross-platform experience when using windows and wsl2.

editorconfig reflects the variety of editors/ides I'm having to use across
platforms and is supported, at least, by vim, emacs, vscode and goland.

--- demonstration ---

I created a fake .vimrc that set tab size to 9 and told it to replace tabs with spaces too, then applied the editor config:

https://www.youtube.com/watch?v=TaF7OJcM7Xk
