### PR TITLE
Dev/equal

### DIFF
--- a/example/astx/token/token.go
+++ b/example/astx/token/token.go
@@ -3,6 +3,7 @@
 package token
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"unicode/utf8"
@@ -56,6 +57,17 @@ func (m TokenMap) TokenString(tok *Token) string {
 
 func (m TokenMap) StringType(typ Type) string {
 	return fmt.Sprintf("%s(%d)", m.Id(typ), typ)
+}
+
+// Equal implements the Equal interface for Token, returning true if the
+// token Type and Lit are matches.
+func (t *Token) Equal(rhs interface{}) bool {
+	switch rhsT := rhs.(type) {
+	case *Token:
+		return t == rhsT || (t.Type == rhsT.Type && bytes.Equal(t.Lit, rhsT.Lit))
+	default:
+		return false
+	}
 }
 
 // CharLiteralValue returns the string value of the char literal.

--- a/example/bools/token/token.go
+++ b/example/bools/token/token.go
@@ -3,6 +3,7 @@
 package token
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"unicode/utf8"
@@ -56,6 +57,17 @@ func (m TokenMap) TokenString(tok *Token) string {
 
 func (m TokenMap) StringType(typ Type) string {
 	return fmt.Sprintf("%s(%d)", m.Id(typ), typ)
+}
+
+// Equal implements the Equal interface for Token, returning true if the
+// token Type and Lit are matches.
+func (t *Token) Equal(rhs interface{}) bool {
+	switch rhsT := rhs.(type) {
+	case *Token:
+		return t == rhsT || (t.Type == rhsT.Type && bytes.Equal(t.Lit, rhsT.Lit))
+	default:
+		return false
+	}
 }
 
 // CharLiteralValue returns the string value of the char literal.

--- a/example/calc/token/token.go
+++ b/example/calc/token/token.go
@@ -3,6 +3,7 @@
 package token
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"unicode/utf8"
@@ -56,6 +57,17 @@ func (m TokenMap) TokenString(tok *Token) string {
 
 func (m TokenMap) StringType(typ Type) string {
 	return fmt.Sprintf("%s(%d)", m.Id(typ), typ)
+}
+
+// Equal implements the Equal interface for Token, returning true if the
+// token Type and Lit are matches.
+func (t *Token) Equal(rhs interface{}) bool {
+	switch rhsT := rhs.(type) {
+	case *Token:
+		return t == rhsT || (t.Type == rhsT.Type && bytes.Equal(t.Lit, rhsT.Lit))
+	default:
+		return false
+	}
 }
 
 // CharLiteralValue returns the string value of the char literal.

--- a/example/errorrecovery/token/token.go
+++ b/example/errorrecovery/token/token.go
@@ -3,6 +3,7 @@
 package token
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"unicode/utf8"
@@ -56,6 +57,17 @@ func (m TokenMap) TokenString(tok *Token) string {
 
 func (m TokenMap) StringType(typ Type) string {
 	return fmt.Sprintf("%s(%d)", m.Id(typ), typ)
+}
+
+// Equal implements the Equal interface for Token, returning true if the
+// token Type and Lit are matches.
+func (t *Token) Equal(rhs interface{}) bool {
+	switch rhsT := rhs.(type) {
+	case *Token:
+		return t == rhsT || (t.Type == rhsT.Type && bytes.Equal(t.Lit, rhsT.Lit))
+	default:
+		return false
+	}
 }
 
 // CharLiteralValue returns the string value of the char literal.

--- a/example/mail/token/token.go
+++ b/example/mail/token/token.go
@@ -3,6 +3,7 @@
 package token
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"unicode/utf8"
@@ -56,6 +57,17 @@ func (m TokenMap) TokenString(tok *Token) string {
 
 func (m TokenMap) StringType(typ Type) string {
 	return fmt.Sprintf("%s(%d)", m.Id(typ), typ)
+}
+
+// Equal implements the Equal interface for Token, returning true if the
+// token Type and Lit are matches.
+func (t *Token) Equal(rhs interface{}) bool {
+	switch rhsT := rhs.(type) {
+	case *Token:
+		return t == rhsT || (t.Type == rhsT.Type && bytes.Equal(t.Lit, rhsT.Lit))
+	default:
+		return false
+	}
 }
 
 // CharLiteralValue returns the string value of the char literal.

--- a/example/nolexer/token/token.go
+++ b/example/nolexer/token/token.go
@@ -3,6 +3,7 @@
 package token
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"unicode/utf8"
@@ -56,6 +57,17 @@ func (m TokenMap) TokenString(tok *Token) string {
 
 func (m TokenMap) StringType(typ Type) string {
 	return fmt.Sprintf("%s(%d)", m.Id(typ), typ)
+}
+
+// Equal implements the Equal interface for Token, returning true if the
+// token Type and Lit are matches.
+func (t *Token) Equal(rhs interface{}) bool {
+	switch rhsT := rhs.(type) {
+	case *Token:
+		return t == rhsT || (t.Type == rhsT.Type && bytes.Equal(t.Lit, rhsT.Lit))
+	default:
+		return false
+	}
 }
 
 // CharLiteralValue returns the string value of the char literal.

--- a/example/rr/token/token.go
+++ b/example/rr/token/token.go
@@ -3,6 +3,7 @@
 package token
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"unicode/utf8"
@@ -56,6 +57,17 @@ func (m TokenMap) TokenString(tok *Token) string {
 
 func (m TokenMap) StringType(typ Type) string {
 	return fmt.Sprintf("%s(%d)", m.Id(typ), typ)
+}
+
+// Equal implements the Equal interface for Token, returning true if the
+// token Type and Lit are matches.
+func (t *Token) Equal(rhs interface{}) bool {
+	switch rhsT := rhs.(type) {
+	case *Token:
+		return t == rhsT || (t.Type == rhsT.Type && bytes.Equal(t.Lit, rhsT.Lit))
+	default:
+		return false
+	}
 }
 
 // CharLiteralValue returns the string value of the char literal.

--- a/example/sr/token/token.go
+++ b/example/sr/token/token.go
@@ -3,6 +3,7 @@
 package token
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"unicode/utf8"
@@ -56,6 +57,17 @@ func (m TokenMap) TokenString(tok *Token) string {
 
 func (m TokenMap) StringType(typ Type) string {
 	return fmt.Sprintf("%s(%d)", m.Id(typ), typ)
+}
+
+// Equal implements the Equal interface for Token, returning true if the
+// token Type and Lit are matches.
+func (t *Token) Equal(rhs interface{}) bool {
+	switch rhsT := rhs.(type) {
+	case *Token:
+		return t == rhsT || (t.Type == rhsT.Type && bytes.Equal(t.Lit, rhsT.Lit))
+	default:
+		return false
+	}
 }
 
 // CharLiteralValue returns the string value of the char literal.

--- a/internal/test/t1/t1_test.go
+++ b/internal/test/t1/t1_test.go
@@ -6,7 +6,12 @@ import (
 	"github.com/goccmack/gocc/internal/test/t1/errors"
 	"github.com/goccmack/gocc/internal/test/t1/lexer"
 	"github.com/goccmack/gocc/internal/test/t1/parser"
+	"github.com/goccmack/gocc/internal/test/t1/token"
 )
+
+type Equaler interface {
+	Equal(interface{}) bool
+}
 
 func Test1(t *testing.T) {
 	ast, err := parser.NewParser().Parse(lexer.NewLexer([]byte(`c`)))
@@ -73,4 +78,82 @@ func Test3(t *testing.T) {
 			t.Fatal("errs.ErrorToken.Column = ", errs.ErrorToken.Column, " != 3")
 		}
 	}
+}
+
+// Tests that require access to the generated go, but interact directly
+// with components.
+
+func mockToken(name string, tokenType token.Type, line, column int) *token.Token {
+	return &token.Token{
+		Type: tokenType,
+		Lit:  []byte(name),
+		Pos:  token.Pos{Offset: (line-1)*80 + column, Line: line, Column: column},
+	}
+}
+
+// assertEqualityIs will verify that lhs.Equal(rhs) and rhs.Equal(lhs) is true/false
+// depending on 'equality'.
+func assertEqualityIs(t *testing.T, lhs, rhs Equaler, equality bool) {
+	t.Helper()
+	if lhs.Equal(rhs) != equality {
+		t.Fatalf("expected lhs.Equal(rhs) to be %v: %v vs %v", equality, lhs, rhs)
+	}
+	if rhs.Equal(lhs) != equality {
+		t.Fatalf("expected rhs.Equal(lhs) to be %v: %v vs %v", equality, rhs, lhs)
+	}
+}
+
+func assertEqual(t *testing.T, lhs, rhs Equaler) {
+	t.Helper()
+	assertEqualityIs(t, lhs, rhs, true)
+}
+
+func assertNotEqual(t *testing.T, lhs, rhs Equaler) {
+	t.Helper()
+	assertEqualityIs(t, lhs, rhs, false)
+}
+
+func Test_Token(t *testing.T) {
+	var (
+		t1 = mockToken("1st", 101, 7, 11)
+		t2 = mockToken("2nd", 9010, 15, 22)
+		t3 = mockToken("3rd", 101, 7, 15)
+		t4 = mockToken("bad", token.INVALID, 1, 1)
+		t5 = mockToken("bad", token.EOF, 1, 1)
+	)
+	// none should be equal: assertNotEqual tests symterrically, so we only need
+	// to compare one way.
+	assertNotEqual(t, t1, t2)
+	assertNotEqual(t, t1, t3)
+	assertNotEqual(t, t1, t4)
+	assertNotEqual(t, t2, t5)
+	assertNotEqual(t, t2, t3)
+	assertNotEqual(t, t2, t4)
+	assertNotEqual(t, t2, t5)
+	assertNotEqual(t, t3, t4)
+	assertNotEqual(t, t3, t5)
+	assertNotEqual(t, t4, t5)
+
+	// They should self-equal, because of the short-circuit
+	assertEqual(t, t1, t1)
+	assertEqual(t, t2, t2)
+	assertEqual(t, t3, t3)
+	assertEqual(t, t4, t4)
+	assertEqual(t, t5, t5)
+
+	// Test an explicit value match by creating a new token that
+	// does not match t1 and incrementally bringing it closer.
+	altT1 := mockToken("x", 1000, 100, 10)
+	assertNotEqual(t, t1, altT1)
+
+	altT1.Type = t1.Type
+	assertNotEqual(t, t1, altT1)
+
+	altT1.Lit = []byte("1st")
+	altT1.Type = 999
+	assertNotEqual(t, t1, altT1)
+
+	// meet the equality criteria.
+	altT1.Type = t1.Type
+	assertEqual(t, t1, altT1)
 }

--- a/internal/test/t1/token/token.go
+++ b/internal/test/t1/token/token.go
@@ -3,6 +3,7 @@
 package token
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"unicode/utf8"
@@ -56,6 +57,17 @@ func (m TokenMap) TokenString(tok *Token) string {
 
 func (m TokenMap) StringType(typ Type) string {
 	return fmt.Sprintf("%s(%d)", m.Id(typ), typ)
+}
+
+// Equal implements the Equal interface for Token, returning true if the
+// token Type and Lit are matches.
+func (t *Token) Equal(rhs interface{}) bool {
+	switch rhsT := rhs.(type) {
+	case *Token:
+		return t == rhsT || (t.Type == rhsT.Type && bytes.Equal(t.Lit, rhsT.Lit))
+	default:
+		return false
+	}
 }
 
 // CharLiteralValue returns the string value of the char literal.

--- a/internal/token/gen/golang/token.go
+++ b/internal/token/gen/golang/token.go
@@ -66,6 +66,7 @@ const TokenMapSrc string = `
 package token
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"unicode/utf8"
@@ -119,6 +120,17 @@ func (m TokenMap) TokenString(tok *Token) string {
 
 func (m TokenMap) StringType(typ Type) string {
 	return fmt.Sprintf("%s(%d)", m.Id(typ), typ)
+}
+
+// Equal implements the Equal interface for Token, returning true if the
+// token Type and Lit are matches.
+func (t *Token) Equal(rhs interface{}) bool {
+	switch rhsT := rhs.(type) {
+	case *Token:
+		return t == rhsT || (t.Type == rhsT.Type && bytes.Equal(t.Lit, rhsT.Lit))
+	default:
+		return false
+	}
 }
 
 // CharLiteralValue returns the string value of the char literal.


### PR DESCRIPTION
Implement Equaler for Token

Added an `Equal(interface{}) bool` method to `token.Token` to comply with the general `Equaler` interface, although it wouldn't be unreasonable to restrict it to `*token.Token` and let developers get a type-panic if they cross their streams?

Unit tests are in internal/test/t1 along with some helper functions (I'm used to using github.com/stretchr/testify, and I guess it shows? :)