### PR TITLE
Replace hardcoded "$" EOF characters by something less general

### DIFF
--- a/example/astx/parser/actiontable.go
+++ b/example/astx/parser/actiontable.go
@@ -15,7 +15,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(3), // id
 		},
 	},
@@ -23,7 +23,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,          // INVALID
-			accept(true), // $
+			accept(true), // ␚
 			shift(3),     // id
 		},
 	},
@@ -31,7 +31,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: StmtList
+			reduce(1), // ␚, reduce: StmtList
 			reduce(1), // id, reduce: StmtList
 		},
 	},
@@ -39,7 +39,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(3), // $, reduce: Stmt
+			reduce(3), // ␚, reduce: Stmt
 			reduce(3), // id, reduce: Stmt
 		},
 	},
@@ -47,7 +47,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(2), // $, reduce: StmtList
+			reduce(2), // ␚, reduce: StmtList
 			reduce(2), // id, reduce: StmtList
 		},
 	},

--- a/example/astx/token/token.go
+++ b/example/astx/token/token.go
@@ -137,13 +137,13 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"id",
 	},
 
 	idMap: map[string]Type{
 		"INVALID": 0,
-		"$":       1,
+		"␚":       1,
 		"id":      2,
 	},
 }

--- a/example/bools/parser/actiontable.go
+++ b/example/bools/parser/actiontable.go
@@ -15,7 +15,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			shift(4),  // (
@@ -33,7 +33,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,          // INVALID
-			accept(true), // $
+			accept(true), // ␚
 			shift(11),    // &
 			shift(12),    // |
 			nil,          // (
@@ -51,7 +51,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: BoolExpr
+			reduce(1), // ␚, reduce: BoolExpr
 			reduce(1), // &, reduce: BoolExpr
 			reduce(1), // |, reduce: BoolExpr
 			nil,       // (
@@ -69,7 +69,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(2), // $, reduce: BoolExpr1
+			reduce(2), // ␚, reduce: BoolExpr1
 			reduce(2), // &, reduce: BoolExpr1
 			reduce(2), // |, reduce: BoolExpr1
 			nil,       // (
@@ -87,7 +87,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			shift(16), // (
@@ -105,7 +105,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(6), // $, reduce: Val
+			reduce(6), // ␚, reduce: Val
 			reduce(6), // &, reduce: Val
 			reduce(6), // |, reduce: Val
 			nil,       // (
@@ -123,7 +123,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(7), // $, reduce: Val
+			reduce(7), // ␚, reduce: Val
 			reduce(7), // &, reduce: Val
 			reduce(7), // |, reduce: Val
 			nil,       // (
@@ -141,7 +141,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(8), // $, reduce: Val
+			reduce(8), // ␚, reduce: Val
 			reduce(8), // &, reduce: Val
 			reduce(8), // |, reduce: Val
 			nil,       // (
@@ -159,7 +159,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(9), // $, reduce: Val
+			reduce(9), // ␚, reduce: Val
 			reduce(9), // &, reduce: Val
 			reduce(9), // |, reduce: Val
 			nil,       // (
@@ -177,7 +177,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			nil,       // (
@@ -195,7 +195,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			nil,       // (
@@ -213,7 +213,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			shift(4),  // (
@@ -231,7 +231,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			shift(4),  // (
@@ -249,7 +249,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			shift(29), // &
 			shift(30), // |
 			nil,       // (
@@ -267,7 +267,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(1), // &, reduce: BoolExpr
 			reduce(1), // |, reduce: BoolExpr
 			nil,       // (
@@ -285,7 +285,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(2), // &, reduce: BoolExpr1
 			reduce(2), // |, reduce: BoolExpr1
 			nil,       // (
@@ -303,7 +303,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			shift(16), // (
@@ -321,7 +321,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(6), // &, reduce: Val
 			reduce(6), // |, reduce: Val
 			nil,       // (
@@ -339,7 +339,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(7), // &, reduce: Val
 			reduce(7), // |, reduce: Val
 			nil,       // (
@@ -357,7 +357,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(8), // &, reduce: Val
 			reduce(8), // |, reduce: Val
 			nil,       // (
@@ -375,7 +375,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(9), // &, reduce: Val
 			reduce(9), // |, reduce: Val
 			nil,       // (
@@ -393,7 +393,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			nil,       // (
@@ -411,7 +411,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			nil,       // (
@@ -429,7 +429,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			nil,       // (
@@ -447,7 +447,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			nil,       // (
@@ -465,7 +465,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			nil,       // (
@@ -483,7 +483,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			shift(11), // &
 			shift(12), // |
 			nil,       // (
@@ -501,7 +501,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(3), // $, reduce: BoolExpr1
+			reduce(3), // ␚, reduce: BoolExpr1
 			reduce(1), // &, reduce: BoolExpr
 			reduce(1), // |, reduce: BoolExpr
 			nil,       // (
@@ -519,7 +519,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(4), // $, reduce: BoolExpr1
+			reduce(4), // ␚, reduce: BoolExpr1
 			reduce(1), // &, reduce: BoolExpr
 			reduce(1), // |, reduce: BoolExpr
 			nil,       // (
@@ -537,7 +537,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			shift(16), // (
@@ -555,7 +555,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			shift(16), // (
@@ -573,7 +573,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(5), // $, reduce: BoolExpr1
+			reduce(5), // ␚, reduce: BoolExpr1
 			reduce(5), // &, reduce: BoolExpr1
 			reduce(5), // |, reduce: BoolExpr1
 			nil,       // (
@@ -591,7 +591,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			shift(29), // &
 			shift(30), // |
 			nil,       // (
@@ -609,7 +609,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			nil,       // (
@@ -627,7 +627,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			nil,       // (
@@ -645,7 +645,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // &
 			nil,       // |
 			nil,       // (
@@ -663,7 +663,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        // INVALID
-			reduce(10), // $, reduce: CompareExpr
+			reduce(10), // ␚, reduce: CompareExpr
 			reduce(10), // &, reduce: CompareExpr
 			reduce(10), // |, reduce: CompareExpr
 			nil,        // (
@@ -681,7 +681,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        // INVALID
-			reduce(11), // $, reduce: CompareExpr
+			reduce(11), // ␚, reduce: CompareExpr
 			reduce(11), // &, reduce: CompareExpr
 			reduce(11), // |, reduce: CompareExpr
 			nil,        // (
@@ -699,7 +699,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        // INVALID
-			reduce(12), // $, reduce: SubStringExpr
+			reduce(12), // ␚, reduce: SubStringExpr
 			reduce(12), // &, reduce: SubStringExpr
 			reduce(12), // |, reduce: SubStringExpr
 			nil,        // (
@@ -717,7 +717,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			shift(29), // &
 			shift(30), // |
 			nil,       // (
@@ -735,7 +735,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(1), // &, reduce: BoolExpr
 			reduce(1), // |, reduce: BoolExpr
 			nil,       // (
@@ -753,7 +753,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(1), // &, reduce: BoolExpr
 			reduce(1), // |, reduce: BoolExpr
 			nil,       // (
@@ -771,7 +771,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(5), // &, reduce: BoolExpr1
 			reduce(5), // |, reduce: BoolExpr1
 			nil,       // (
@@ -789,7 +789,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        // INVALID
-			nil,        // $
+			nil,        // ␚
 			reduce(10), // &, reduce: CompareExpr
 			reduce(10), // |, reduce: CompareExpr
 			nil,        // (
@@ -807,7 +807,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        // INVALID
-			nil,        // $
+			nil,        // ␚
 			reduce(11), // &, reduce: CompareExpr
 			reduce(11), // |, reduce: CompareExpr
 			nil,        // (
@@ -825,7 +825,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        // INVALID
-			nil,        // $
+			nil,        // ␚
 			reduce(12), // &, reduce: SubStringExpr
 			reduce(12), // |, reduce: SubStringExpr
 			nil,        // (

--- a/example/bools/token/token.go
+++ b/example/bools/token/token.go
@@ -137,7 +137,7 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"&",
 		"|",
 		"(",
@@ -153,7 +153,7 @@ var TokMap = TokenMap{
 
 	idMap: map[string]Type{
 		"INVALID":    0,
-		"$":          1,
+		"␚":          1,
 		"&":          2,
 		"|":          3,
 		"(":          4,

--- a/example/calc/parser/actiontable.go
+++ b/example/calc/parser/actiontable.go
@@ -15,7 +15,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			nil,      // +
 			nil,      // *
 			shift(5), // (
@@ -27,7 +27,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,          // INVALID
-			accept(true), // $
+			accept(true), // ␚
 			nil,          // +
 			nil,          // *
 			nil,          // (
@@ -39,7 +39,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: Calc
+			reduce(1), // ␚, reduce: Calc
 			shift(7),  // +
 			nil,       // *
 			nil,       // (
@@ -51,7 +51,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(3), // $, reduce: Expr
+			reduce(3), // ␚, reduce: Expr
 			reduce(3), // +, reduce: Expr
 			shift(8),  // *
 			nil,       // (
@@ -63,7 +63,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(5), // $, reduce: Term
+			reduce(5), // ␚, reduce: Term
 			reduce(5), // +, reduce: Term
 			reduce(5), // *, reduce: Term
 			nil,       // (
@@ -75,7 +75,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // +
 			nil,       // *
 			shift(12), // (
@@ -87,7 +87,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(7), // $, reduce: Factor
+			reduce(7), // ␚, reduce: Factor
 			reduce(7), // +, reduce: Factor
 			reduce(7), // *, reduce: Factor
 			nil,       // (
@@ -99,7 +99,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			nil,      // +
 			nil,      // *
 			shift(5), // (
@@ -111,7 +111,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			nil,      // +
 			nil,      // *
 			shift(5), // (
@@ -123,7 +123,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			shift(16), // +
 			nil,       // *
 			nil,       // (
@@ -135,7 +135,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(3), // +, reduce: Expr
 			shift(18), // *
 			nil,       // (
@@ -147,7 +147,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(5), // +, reduce: Term
 			reduce(5), // *, reduce: Term
 			nil,       // (
@@ -159,7 +159,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // +
 			nil,       // *
 			shift(12), // (
@@ -171,7 +171,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(7), // +, reduce: Factor
 			reduce(7), // *, reduce: Factor
 			nil,       // (
@@ -183,7 +183,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(2), // $, reduce: Expr
+			reduce(2), // ␚, reduce: Expr
 			reduce(2), // +, reduce: Expr
 			shift(8),  // *
 			nil,       // (
@@ -195,7 +195,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(4), // $, reduce: Term
+			reduce(4), // ␚, reduce: Term
 			reduce(4), // +, reduce: Term
 			reduce(4), // *, reduce: Term
 			nil,       // (
@@ -207,7 +207,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // +
 			nil,       // *
 			shift(12), // (
@@ -219,7 +219,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(6), // $, reduce: Factor
+			reduce(6), // ␚, reduce: Factor
 			reduce(6), // +, reduce: Factor
 			reduce(6), // *, reduce: Factor
 			nil,       // (
@@ -231,7 +231,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // +
 			nil,       // *
 			shift(12), // (
@@ -243,7 +243,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			shift(16), // +
 			nil,       // *
 			nil,       // (
@@ -255,7 +255,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(2), // +, reduce: Expr
 			shift(18), // *
 			nil,       // (
@@ -267,7 +267,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(4), // +, reduce: Term
 			reduce(4), // *, reduce: Term
 			nil,       // (
@@ -279,7 +279,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(6), // +, reduce: Factor
 			reduce(6), // *, reduce: Factor
 			nil,       // (

--- a/example/calc/token/token.go
+++ b/example/calc/token/token.go
@@ -137,7 +137,7 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"+",
 		"*",
 		"(",
@@ -147,7 +147,7 @@ var TokMap = TokenMap{
 
 	idMap: map[string]Type{
 		"INVALID": 0,
-		"$":       1,
+		"␚":       1,
 		"+":       2,
 		"*":       3,
 		"(":       4,

--- a/example/errormsg/parser/actiontable.go
+++ b/example/errormsg/parser/actiontable.go
@@ -15,7 +15,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(2), // var
 			nil,      // ;
 			nil,      // identifier
@@ -30,7 +30,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,          // INVALID
-			accept(true), // $
+			accept(true), // ␚
 			nil,          // var
 			nil,          // ;
 			nil,          // identifier
@@ -45,7 +45,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			nil,      // var
 			nil,      // ;
 			shift(4), // identifier
@@ -60,7 +60,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			nil,      // var
 			shift(7), // ;
 			nil,      // identifier
@@ -75,7 +75,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // var
 			reduce(3), // ;, reduce: Name
 			nil,       // identifier
@@ -90,7 +90,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // var
 			reduce(4), // ;, reduce: Name
 			nil,       // identifier
@@ -105,7 +105,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // var
 			nil,       // ;
 			shift(11), // identifier
@@ -120,7 +120,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(2), // $, reduce: Declaration
+			reduce(2), // ␚, reduce: Declaration
 			nil,       // var
 			nil,       // ;
 			nil,       // identifier
@@ -135,7 +135,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // var
 			nil,       // ;
 			reduce(5), // identifier, reduce: Equal
@@ -150,7 +150,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // var
 			nil,       // ;
 			reduce(6), // identifier, reduce: Equal
@@ -165,7 +165,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // var
 			shift(15), // ;
 			nil,       // identifier
@@ -180,7 +180,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // var
 			reduce(7), // ;, reduce: Default
 			nil,       // identifier
@@ -195,7 +195,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // var
 			reduce(8), // ;, reduce: Default
 			nil,       // identifier
@@ -210,7 +210,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // var
 			reduce(9), // ;, reduce: Default
 			nil,       // identifier
@@ -225,7 +225,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,        // INVALID
-			nil,        // $
+			nil,        // ␚
 			nil,        // var
 			reduce(10), // ;, reduce: Default
 			nil,        // identifier
@@ -240,7 +240,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: Declaration
+			reduce(1), // ␚, reduce: Declaration
 			nil,       // var
 			nil,       // ;
 			nil,       // identifier

--- a/example/errormsg/token/token.go
+++ b/example/errormsg/token/token.go
@@ -137,7 +137,7 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"var",
 		";",
 		"identifier",
@@ -150,7 +150,7 @@ var TokMap = TokenMap{
 
 	idMap: map[string]Type{
 		"INVALID":    0,
-		"$":          1,
+		"␚":          1,
 		"var":        2,
 		";":          3,
 		"identifier": 4,

--- a/example/errorrecovery/parser/actiontable.go
+++ b/example/errorrecovery/parser/actiontable.go
@@ -15,7 +15,7 @@ var actionTab = actionTable{
 		canRecover: true,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(3), // id
 			shift(4), // error
 		},
@@ -24,7 +24,7 @@ var actionTab = actionTable{
 		canRecover: true,
 		actions: [numSymbols]action{
 			nil,          // INVALID
-			accept(true), // $
+			accept(true), // ␚
 			shift(3),     // id
 			shift(4),     // error
 		},
@@ -33,7 +33,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: StmtList
+			reduce(1), // ␚, reduce: StmtList
 			reduce(1), // id, reduce: StmtList
 			reduce(1), // error, reduce: StmtList
 		},
@@ -42,7 +42,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(3), // $, reduce: Stmt
+			reduce(3), // ␚, reduce: Stmt
 			reduce(3), // id, reduce: Stmt
 			reduce(3), // error, reduce: Stmt
 		},
@@ -51,7 +51,7 @@ var actionTab = actionTable{
 		canRecover: true,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(4), // $, reduce: Stmt
+			reduce(4), // ␚, reduce: Stmt
 			reduce(4), // id, reduce: Stmt
 			reduce(4), // error, reduce: Stmt
 		},
@@ -60,7 +60,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(2), // $, reduce: StmtList
+			reduce(2), // ␚, reduce: StmtList
 			reduce(2), // id, reduce: StmtList
 			reduce(2), // error, reduce: StmtList
 		},

--- a/example/errorrecovery/token/token.go
+++ b/example/errorrecovery/token/token.go
@@ -137,14 +137,14 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"id",
 		"error",
 	},
 
 	idMap: map[string]Type{
 		"INVALID": 0,
-		"$":       1,
+		"␚":       1,
 		"id":      2,
 		"error":   3,
 	},

--- a/example/mail/token/token.go
+++ b/example/mail/token/token.go
@@ -137,13 +137,13 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"addrspec",
 	},
 
 	idMap: map[string]Type{
 		"INVALID":  0,
-		"$":        1,
+		"␚":        1,
 		"addrspec": 2,
 	},
 }

--- a/example/nolexer/parser/actiontable.go
+++ b/example/nolexer/parser/actiontable.go
@@ -15,7 +15,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			nil,      // name
 			shift(3), // hello
 			shift(4), // hiya
@@ -25,7 +25,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,          // INVALID
-			accept(true), // $
+			accept(true), // ␚
 			nil,          // name
 			nil,          // hello
 			nil,          // hiya
@@ -35,7 +35,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(5), // name
 			nil,      // hello
 			nil,      // hiya
@@ -45,7 +45,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(2), // name, reduce: Saying
 			nil,       // hello
 			nil,       // hiya
@@ -55,7 +55,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(3), // name, reduce: Saying
 			nil,       // hello
 			nil,       // hiya
@@ -65,7 +65,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: Hello
+			reduce(1), // ␚, reduce: Hello
 			nil,       // name
 			nil,       // hello
 			nil,       // hiya

--- a/example/nolexer/token/token.go
+++ b/example/nolexer/token/token.go
@@ -137,7 +137,7 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"name",
 		"hello",
 		"hiya",
@@ -145,7 +145,7 @@ var TokMap = TokenMap{
 
 	idMap: map[string]Type{
 		"INVALID": 0,
-		"$":       1,
+		"␚":       1,
 		"name":    2,
 		"hello":   3,
 		"hiya":    4,

--- a/example/rr/parser/actiontable.go
+++ b/example/rr/parser/actiontable.go
@@ -15,7 +15,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(4), // a
 			shift(5), // c
 		},
@@ -24,7 +24,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,          // INVALID
-			accept(true), // $
+			accept(true), // ␚
 			nil,          // a
 			nil,          // c
 		},
@@ -33,7 +33,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: RR
+			reduce(1), // ␚, reduce: RR
 			shift(6),  // a
 			nil,       // c
 		},
@@ -42,7 +42,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(2), // $, reduce: RR
+			reduce(2), // ␚, reduce: RR
 			nil,       // a
 			nil,       // c
 		},
@@ -51,7 +51,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(3), // $, reduce: B
+			reduce(3), // ␚, reduce: B
 			reduce(4), // a, reduce: A
 			nil,       // c
 		},
@@ -60,7 +60,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(6), // $, reduce: A
+			reduce(6), // ␚, reduce: A
 			reduce(6), // a, reduce: A
 			nil,       // c
 		},
@@ -69,7 +69,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(5), // $, reduce: A
+			reduce(5), // ␚, reduce: A
 			reduce(5), // a, reduce: A
 			nil,       // c
 		},

--- a/example/rr/token/token.go
+++ b/example/rr/token/token.go
@@ -137,14 +137,14 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"a",
 		"c",
 	},
 
 	idMap: map[string]Type{
 		"INVALID": 0,
-		"$":       1,
+		"␚":       1,
 		"a":       2,
 		"c":       3,
 	},

--- a/example/sr/parser/actiontable.go
+++ b/example/sr/parser/actiontable.go
@@ -15,7 +15,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(2), // if
 			shift(3), // id
 			nil,      // then
@@ -26,7 +26,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,          // INVALID
-			accept(true), // $
+			accept(true), // ␚
 			nil,          // if
 			nil,          // id
 			nil,          // then
@@ -37,7 +37,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			nil,      // if
 			shift(4), // id
 			nil,      // then
@@ -48,7 +48,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(3), // $, reduce: Stmt
+			reduce(3), // ␚, reduce: Stmt
 			nil,       // if
 			nil,       // id
 			nil,       // then
@@ -59,7 +59,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			nil,      // if
 			nil,      // id
 			shift(5), // then
@@ -70,7 +70,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(7), // if
 			shift(8), // id
 			nil,      // then
@@ -81,7 +81,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: Stmt
+			reduce(1), // ␚, reduce: Stmt
 			nil,       // if
 			nil,       // id
 			nil,       // then
@@ -92,7 +92,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // if
 			shift(10), // id
 			nil,       // then
@@ -103,7 +103,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(3), // $, reduce: Stmt
+			reduce(3), // ␚, reduce: Stmt
 			nil,       // if
 			nil,       // id
 			nil,       // then
@@ -114,7 +114,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(2), // if
 			shift(3), // id
 			nil,      // then
@@ -125,7 +125,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			nil,       // if
 			nil,       // id
 			shift(12), // then
@@ -136,7 +136,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(2), // $, reduce: Stmt
+			reduce(2), // ␚, reduce: Stmt
 			nil,       // if
 			nil,       // id
 			nil,       // then
@@ -147,7 +147,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(7), // if
 			shift(8), // id
 			nil,      // then
@@ -158,7 +158,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: Stmt
+			reduce(1), // ␚, reduce: Stmt
 			nil,       // if
 			nil,       // id
 			nil,       // then
@@ -169,7 +169,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(7), // if
 			shift(8), // id
 			nil,      // then
@@ -180,7 +180,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(2), // $, reduce: Stmt
+			reduce(2), // ␚, reduce: Stmt
 			nil,       // if
 			nil,       // id
 			nil,       // then

--- a/example/sr/token/token.go
+++ b/example/sr/token/token.go
@@ -137,7 +137,7 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"if",
 		"id",
 		"then",
@@ -146,7 +146,7 @@ var TokMap = TokenMap{
 
 	idMap: map[string]Type{
 		"INVALID": 0,
-		"$":       1,
+		"␚":       1,
 		"if":      2,
 		"id":      3,
 		"then":    4,

--- a/example/usercontext/parser/actiontable.go
+++ b/example/usercontext/parser/actiontable.go
@@ -15,7 +15,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			nil,      // ...42...
 			shift(3), // capitalized
 			shift(4), // lowercase
@@ -25,7 +25,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,          // INVALID
-			accept(true), // $
+			accept(true), // ␚
 			nil,          // ...42...
 			nil,          // capitalized
 			nil,          // lowercase
@@ -35,7 +35,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(5), // ...42...
 			shift(6), // capitalized
 			shift(7), // lowercase
@@ -45,7 +45,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(2), // ...42..., reduce: Words
 			reduce(2), // capitalized, reduce: Words
 			reduce(2), // lowercase, reduce: Words
@@ -55,7 +55,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(4), // ...42..., reduce: Words
 			reduce(4), // capitalized, reduce: Words
 			reduce(4), // lowercase, reduce: Words
@@ -65,7 +65,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: Grammar
+			reduce(1), // ␚, reduce: Grammar
 			nil,       // ...42...
 			nil,       // capitalized
 			nil,       // lowercase
@@ -75,7 +75,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(3), // ...42..., reduce: Words
 			reduce(3), // capitalized, reduce: Words
 			reduce(3), // lowercase, reduce: Words
@@ -85,7 +85,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(5), // ...42..., reduce: Words
 			reduce(5), // capitalized, reduce: Words
 			reduce(5), // lowercase, reduce: Words

--- a/example/usercontext/token/token.go
+++ b/example/usercontext/token/token.go
@@ -137,7 +137,7 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"...42...",
 		"capitalized",
 		"lowercase",
@@ -145,7 +145,7 @@ var TokMap = TokenMap{
 
 	idMap: map[string]Type{
 		"INVALID":     0,
-		"$":           1,
+		"␚":           1,
 		"...42...":    2,
 		"capitalized": 3,
 		"lowercase":   4,

--- a/internal/ast/syntaxeof.go
+++ b/internal/ast/syntaxeof.go
@@ -19,9 +19,9 @@ type SyntaxEof int
 var EOF SyntaxEof = 0
 
 func (SyntaxEof) SymbolsString() string {
-	return "$"
+	return "␚"
 }
 
 func (SyntaxEof) String() string {
-	return "$"
+	return "␚"
 }

--- a/internal/frontend/scanner/scanner.go
+++ b/internal/frontend/scanner/scanner.go
@@ -480,7 +480,7 @@ scanAgain:
 		S.next() // always make progress
 		switch ch {
 		case -1:
-			tok = S.tokenMap.Type("$")
+			tok = S.tokenMap.Type("␚")
 		case '"':
 			tok = S.tokenMap.Type("string_lit")
 			S.scanString(pos)

--- a/internal/frontend/token/token.go
+++ b/internal/frontend/token/token.go
@@ -33,7 +33,7 @@ func (this *Token) Equals(that *Token) bool {
 func (this *Token) String() string {
 	str := ""
 	if this.Type == EOF {
-		str += "\"$\""
+		str += "\"␚\""
 	} else {
 		str += "\"" + string(this.Lit) + "\""
 	}
@@ -118,7 +118,7 @@ type TokenMap struct {
 
 func NewMap() *TokenMap {
 	tm := &TokenMap{make([]string, 0, 10), make(map[string]Type)}
-	tm.AddToken("$")
+	tm.AddToken("␚")
 	// tm.AddToken("ε")
 	return tm
 }

--- a/internal/parser/lr1/items/item.go
+++ b/internal/parser/lr1/items/item.go
@@ -70,8 +70,8 @@ func NewItem(prodIdx int, prod *ast.SyntaxProd, pos int, followingSymbol string)
 func (this *Item) accept(sym string) bool {
 	return this.ProdIdx == 0 &&
 		this.Pos >= this.Len &&
-		this.FollowingSymbol == "$" &&
-		sym == "$"
+		this.FollowingSymbol == "␚" &&
+		sym == "␚"
 }
 
 // If the action is shift the next state is nextState.

--- a/internal/parser/lr1/items/itemsets.go
+++ b/internal/parser/lr1/items/itemsets.go
@@ -118,6 +118,6 @@ func InitialItemSet(g *ast.Grammar, symbols *symbols.Symbols, fs *first.FirstSet
 	set := NewItemSet(symbols, g.SyntaxPart.ProdList, fs)
 	set.SetNo = 0
 	prod := g.SyntaxPart.ProdList[0]
-	set.AddItem(NewItem(0, prod, 0, "$"))
+	set.AddItem(NewItem(0, prod, 0, "␚"))
 	return set
 }

--- a/internal/parser/symbols/symbols.go
+++ b/internal/parser/symbols/symbols.go
@@ -53,7 +53,7 @@ func NewSymbols(grammar *ast.Grammar) *Symbols {
 	}
 
 	symbols.Add("INVALID")
-	symbols.Add("$")
+	symbols.Add("␚")
 
 	if grammar.SyntaxPart == nil {
 		return symbols

--- a/internal/test/t1/parser/actiontable.go
+++ b/internal/test/t1/parser/actiontable.go
@@ -15,7 +15,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(2), // c, reduce: B
 			nil,       // empty
 			shift(3),  // b
@@ -25,7 +25,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,          // INVALID
-			accept(true), // $
+			accept(true), // ␚
 			nil,          // c
 			nil,          // empty
 			nil,          // b
@@ -35,7 +35,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,      // INVALID
-			nil,      // $
+			nil,      // ␚
 			shift(4), // c
 			nil,      // empty
 			nil,      // b
@@ -45,7 +45,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			nil,       // $
+			nil,       // ␚
 			reduce(3), // c, reduce: B
 			nil,       // empty
 			nil,       // b
@@ -55,7 +55,7 @@ var actionTab = actionTable{
 		canRecover: false,
 		actions: [numSymbols]action{
 			nil,       // INVALID
-			reduce(1), // $, reduce: A
+			reduce(1), // ␚, reduce: A
 			nil,       // c
 			nil,       // empty
 			nil,       // b

--- a/internal/test/t1/token/token.go
+++ b/internal/test/t1/token/token.go
@@ -137,7 +137,7 @@ func (t *Token) StringValue() string {
 var TokMap = TokenMap{
 	typeMap: []string{
 		"INVALID",
-		"$",
+		"␚",
 		"c",
 		"empty",
 		"b",
@@ -145,7 +145,7 @@ var TokMap = TokenMap{
 
 	idMap: map[string]Type{
 		"INVALID": 0,
-		"$":       1,
+		"␚":       1,
 		"c":       2,
 		"empty":   3,
 		"b":       4,


### PR DESCRIPTION
WIP

This fixes #127, however does so in an ugly manner. I just changed every "$" to the SUBstiture character "␚", in hopes that it is used by no one. A better fix would be completely getting rid of a concrete representation of EOF and instead replacing it with an abstract struct, but this would involve refactoring the lexer to use a new interface instead of strings, and I don't know enough about this project to understand what all needs to be changed.

Something else that popped up, is it possible that the `gen.sh` script is outdated? I tried generating a new frontend for gocc, but got a bunch of warnings and the resulting frontend doesn't work:
```
warning: undefined symbol "g_sdt_lit" used in productions ["FileHeader" "SyntaxBody" "SyntaxBody"]
warning: undefined symbol "regDefId" used in productions ["LexProduction" "LexTerm"]
warning: undefined symbol "char_lit" used in productions ["LexTerm" "LexTerm" "LexTerm"]
warning: undefined symbol "prodId" used in productions ["SyntaxProduction" "Symbol"]
warning: undefined symbol "string_lit" used in productions ["Symbol"]
warning: undefined symbol "tokId" used in productions ["LexProduction" "Symbol"]
warning: undefined symbol "ignoredTokId" used in productions ["LexProduction"]
```
This happens on the current master branch too, so I don't think it's due to my additions.

As such, I had to manually change gocc's current frontend to use SUB instead of "$".
